### PR TITLE
Add PATCH /api/users/forgotpassword route

### DIFF
--- a/packages/api-postgres/src/mailer/Mailer.ts
+++ b/packages/api-postgres/src/mailer/Mailer.ts
@@ -4,6 +4,10 @@ import {
     getEmailVerificatonTemplateText,
     getEmailVerificatonTemplateHTML
 } from './templates/emailVerificaton';
+import {
+    getPasswordResetTemplateHTML,
+    getPasswordResetTemplateText
+} from './templates/passwordReset';
 
 interface MailOptions {
     port?: number;
@@ -25,6 +29,24 @@ class Mailer {
                 subject: 'DESC In-Kind Portal Email Verification',
                 text: getEmailVerificatonTemplateText(baseUrl, user.emailVerificationToken),
                 html: getEmailVerificatonTemplateHTML(baseUrl, user.emailVerificationToken)
+            });
+        }
+    }
+
+    public static async sendPasswordResetEmail(baseUrl: string, user: User): Promise<any> {
+        const transporter = nodemailer.createTransport(Mailer.getMailOptions());
+        const verifiedTransporter =
+            process.env.NODE_ENV === 'testingE2E' || process.env.NODE_ENV === 'testing'
+                ? true
+                : await transporter.verify();
+
+        if (verifiedTransporter) {
+            return transporter.sendMail({
+                from: 'portal-admin@desc.org',
+                to: user.email,
+                subject: 'DESC In-Kind Password Reset',
+                text: getPasswordResetTemplateText(baseUrl, user.passwordResetToken),
+                html: getPasswordResetTemplateHTML(baseUrl, user.passwordResetToken)
             });
         }
     }

--- a/packages/api-postgres/src/mailer/__tests__/Mailer.test.ts
+++ b/packages/api-postgres/src/mailer/__tests__/Mailer.test.ts
@@ -14,4 +14,17 @@ describe('Mailer', () => {
             })
         );
     });
+
+    it('sends password reset email', async () => {
+        const testUser = new User();
+        testUser.passwordResetToken = 'randomtokenstringhere';
+        const email = await Mailer.sendPasswordResetEmail('http://localhost:3001', testUser);
+
+        expect(email).toEqual(
+            expect.objectContaining({
+                envelope: expect.any(Object),
+                messageId: expect.any(String)
+            })
+        );
+    });
 });

--- a/packages/api-postgres/src/mailer/templates/passwordReset.ts
+++ b/packages/api-postgres/src/mailer/templates/passwordReset.ts
@@ -1,0 +1,39 @@
+import { styles } from './common';
+
+export function getPasswordResetTemplateHTML(baseUrl: string, token: string): string {
+    return `
+${styles}
+<div class="container">
+    <div class="banner">
+        <p>Password Reset</p>
+    </div>
+    <p class="text">
+        You recently requested to reset your password for the DESC In-Kind Portal. If you did not initiate this request,
+        no action is required.  If you did, then you will need to click on the link below and change your password when
+        redirected to the "Change Password" form.  This link is only valid for the next 2 hours.
+    </p>
+    <a class="btn" href="${baseUrl}/changepassword/${token}">Password Reset</a>
+    <p class="text">or click on the below link:</p>
+    <p class="text"><a href="${baseUrl}/confirmemail/${token}">${baseUrl}/changepassword/${token}</a></p>
+    <p class="text">If you did not request a password reset for your DESC In-Kind Portal account, please disregard this email.</p>
+    <p class="text">Thank you!</p>
+    <p class="text">&mdash; The DESC In-Kind Portal Team</p>
+</div>
+<p class="footer">&copy; 2020 &bull; All Rights Reserved &bull; Downtown Emergency Service Center</p>
+`;
+}
+
+export function getPasswordResetTemplateText(baseUrl: string, token: string): string {
+    return `
+You recently requested to reset your password for the DESC In-Kind Portal. If you did not initiate this request,
+no action is required.  If you did, then you will need to click on the link below and change your password when
+redirected to the "Change Password" form.  This link is only valid for the next 2 hours.
+
+    ${baseUrl}/changepassword/${token}
+
+If you did not request a password reset for your DESC In-Kind Portal account, please disregard this email.
+
+Thank you!
+-- The DESC In-Kind Portal Team
+`;
+}

--- a/packages/api-postgres/src/testUtils/TestClient.ts
+++ b/packages/api-postgres/src/testUtils/TestClient.ts
@@ -83,6 +83,13 @@ class TestClient extends BaseTestClient {
             .set('Content-Type', 'application/json');
     }
 
+    public forgotPassword(email: string): Test {
+        return request(this.app)
+            .patch(`/api/users/forgotpassword`)
+            .set('Content-Type', 'application/json')
+            .send({ email });
+    }
+
     public createItem(itemData: any): Test {
         return request(this.app)
             .post('/api/items')

--- a/packages/api-postgres/src/user/UserController.ts
+++ b/packages/api-postgres/src/user/UserController.ts
@@ -185,6 +185,32 @@ class UserController {
             });
     }
 
+    static forgotPassword(req: Request, res: Response): Promise<Response> {
+        const { email } = req.body;
+        return UserService.generatePasswordResetToken(email).then(async (user) => {
+            if (user) {
+                const baseUrl = (req.get('origin') as string) || '';
+                await Mailer.sendPasswordResetEmail(baseUrl, user);
+
+                return res.json({
+                    success: true,
+                    message: 'password reset instructions sent to user email',
+                    payload: {
+                        user: user.toClientJSON()
+                    }
+                });
+            }
+
+            return res.json({
+                success: false,
+                message: 'user not found',
+                payload: {
+                    user: null
+                }
+            });
+        });
+    }
+
     static async me(req: Request, res: Response): Promise<Response> {
         const baseResponse = {
             success: true,

--- a/packages/api-postgres/src/user/UserRouter.ts
+++ b/packages/api-postgres/src/user/UserRouter.ts
@@ -27,6 +27,7 @@ class UserRouter {
 
     private static defineRoutes(): void {
         UserRouter.router.route('/me').get(checkForRefreshToken, UserController.me);
+        UserRouter.router.route('/forgotpassword').patch(UserController.forgotPassword);
 
         UserRouter.router
             .route('/')
@@ -34,7 +35,7 @@ class UserRouter {
             .get(isAdmin, UserController.getAllUsers);
 
         UserRouter.router
-            .route('/:id')
+            .route('/:id([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})')
             .get(isAdminOrSelf, UserController.getUser)
             .patch(isAdminOrSelf, UserController.updateUser)
             .delete(isAdminOrSelf, UserController.deleteUser);

--- a/packages/api-postgres/src/user/UserService.ts
+++ b/packages/api-postgres/src/user/UserService.ts
@@ -72,6 +72,17 @@ export default class UserService {
         });
     }
 
+    static async generatePasswordResetToken(email: string): Promise<User | undefined> {
+        const user = await UserService.getUserByEmail(email);
+        if (user) {
+            const in2hrs = new Date(Date.now() + 120 * 1000 * 60);
+            user.passwordResetToken = v4();
+            user.passwordResetTokenExpiresAt = in2hrs;
+            await user.save();
+        }
+        return user;
+    }
+
     private static async getUserCount(): Promise<number> {
         const count = await getRepository(User).createQueryBuilder('user').getCount();
         return count;

--- a/packages/api-postgres/src/user/__tests__/UserService.test.ts
+++ b/packages/api-postgres/src/user/__tests__/UserService.test.ts
@@ -191,4 +191,36 @@ describe('User service integration tests', () => {
             expect(result?.emailVerificationToken).toBe('');
         });
     });
+
+    describe('generatePasswordResetToken method', () => {
+        let userEmail: string;
+
+        beforeEach(async () => {
+            const { firstName, lastName, email, password, program } = testUser;
+            const user = await UserService.createUser({
+                firstName,
+                lastName,
+                email,
+                password,
+                program
+            });
+
+            userEmail = user.email;
+        });
+
+        afterEach(async () => {
+            await TestUtils.dropUsers();
+        });
+
+        it('returns undefined if user cannot be found with given email', async () => {
+            const result = await UserService.generatePasswordResetToken('unknown-user@test.com');
+            expect(result).toBeUndefined();
+        });
+
+        it('generates random token to use for password reset', async () => {
+            const result = await UserService.generatePasswordResetToken(userEmail);
+            expect(result?.passwordResetToken.length).toBeGreaterThan(0);
+            expect(result?.passwordResetTokenExpiresAt instanceof Date).toBeTruthy();
+        });
+    });
 });

--- a/packages/api-postgres/src/user/__tests__/user.acceptance-test.ts
+++ b/packages/api-postgres/src/user/__tests__/user.acceptance-test.ts
@@ -388,4 +388,56 @@ describe('User route acceptance tests', () => {
             });
         });
     });
+
+    describe('/api/users/forgotpassword route', () => {
+        let client: TestClient;
+
+        beforeAll(() => {
+            client = new TestClient();
+        });
+
+        afterEach(async () => {
+            await TestUtils.dropUsers();
+        });
+
+        beforeEach(async () => {
+            await TestUtils.createTestUser({
+                firstName: 'Oliver',
+                lastName: 'Queen',
+                email: 'oliver@desc.org',
+                password: '123456',
+                program: Program.SURVIVAL
+            });
+        });
+
+        describe('PATCH request method', () => {
+            it('sends password reset email to user', async () => {
+                const response = await client.forgotPassword('oliver@desc.org');
+
+                expect(response.body).toEqual(
+                    expect.objectContaining({
+                        success: true,
+                        message: 'password reset instructions sent to user email',
+                        payload: expect.objectContaining({
+                            user: expect.any(Object)
+                        })
+                    })
+                );
+            });
+
+            it('returns a null user if the user (email) is not found', async () => {
+                const response = await client.forgotPassword('unknownemail@desc.org');
+
+                expect(response.body).toEqual(
+                    expect.objectContaining({
+                        success: false,
+                        message: 'user not found',
+                        payload: expect.objectContaining({
+                            user: null
+                        })
+                    })
+                );
+            });
+        });
+    });
 });


### PR DESCRIPTION
This is an interim PR to add the API support and endpoint to generate a random token and send the user an email with instructions on how to reset their password.

This is the first step to address issue #25 