### PR TITLE
Add PATCH /api/users/changepassword/:token route

### DIFF
--- a/packages/api-postgres/src/common/DateUtils.ts
+++ b/packages/api-postgres/src/common/DateUtils.ts
@@ -1,0 +1,19 @@
+/**
+ * Date utility class
+ *
+ * The intent of this class is to provide better control over the expiration times of
+ * tokens which is especially useful for testing.
+ */
+class DateUtils {
+    static ONE_MINUTE_IN_MS = 60 * 1000;
+
+    public static getCurrentDateTime(): Date {
+        return new Date();
+    }
+
+    public static getDateMinutesFromNow(minutes: number): Date {
+        return new Date(Date.now() + minutes * DateUtils.ONE_MINUTE_IN_MS);
+    }
+}
+
+export default DateUtils;

--- a/packages/api-postgres/src/entity/User.ts
+++ b/packages/api-postgres/src/entity/User.ts
@@ -58,6 +58,9 @@ export default class User extends BaseEntity {
     @Column({ default: new Date() })
     passwordResetTokenExpiresAt: Date;
 
+    @Column({ default: new Date() })
+    passwordLastChangedAt: Date;
+
     @Column({ nullable: true })
     lastLoginAt: Date;
 

--- a/packages/api-postgres/src/testUtils/TestClient.ts
+++ b/packages/api-postgres/src/testUtils/TestClient.ts
@@ -90,6 +90,13 @@ class TestClient extends BaseTestClient {
             .send({ email });
     }
 
+    public changePassword(token: string, newPassword: string): Test {
+        return request(this.app)
+            .patch(`/api/users/changepassword/${token}`)
+            .set('Content-Type', 'application/json')
+            .send({ newPassword });
+    }
+
     public createItem(itemData: any): Test {
         return request(this.app)
             .post('/api/items')

--- a/packages/api-postgres/src/user/UserController.ts
+++ b/packages/api-postgres/src/user/UserController.ts
@@ -211,6 +211,40 @@ class UserController {
         });
     }
 
+    static changePassword(req: Request, res: Response): Promise<Response> {
+        const resetToken = req.params.token;
+        const { newPassword } = req.body;
+        return UserService.changePassword(resetToken, newPassword)
+            .then((user) => {
+                if (user) {
+                    return res.json({
+                        success: true,
+                        message: 'password changed',
+                        payload: {
+                            user: user.toClientJSON()
+                        }
+                    });
+                } else {
+                    return res.json({
+                        success: false,
+                        message: 'password not changed',
+                        payload: {
+                            user: null
+                        }
+                    });
+                }
+            })
+            .catch(() => {
+                return res.json({
+                    success: false,
+                    message: 'error with reset token',
+                    payload: {
+                        user: null
+                    }
+                });
+            });
+    }
+
     static async me(req: Request, res: Response): Promise<Response> {
         const baseResponse = {
             success: true,

--- a/packages/api-postgres/src/user/UserRouter.ts
+++ b/packages/api-postgres/src/user/UserRouter.ts
@@ -26,13 +26,13 @@ class UserRouter {
     }
 
     private static defineRoutes(): void {
-        UserRouter.router.route('/me').get(checkForRefreshToken, UserController.me);
-        UserRouter.router.route('/forgotpassword').patch(UserController.forgotPassword);
-
         UserRouter.router
             .route('/')
             .post(UserController.createUser)
             .get(isAdmin, UserController.getAllUsers);
+
+        UserRouter.router.route('/me').get(checkForRefreshToken, UserController.me);
+        UserRouter.router.route('/forgotpassword').patch(UserController.forgotPassword);
 
         UserRouter.router
             .route('/:id([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})')
@@ -41,6 +41,7 @@ class UserRouter {
             .delete(isAdminOrSelf, UserController.deleteUser);
 
         UserRouter.router.route('/confirmemail/:token').patch(UserController.confirmEmail);
+        UserRouter.router.route('/changepassword/:token').patch(UserController.changePassword);
     }
 }
 


### PR DESCRIPTION
This is an interim PR to add the API support and endpoint to change a user's password if the user has a valid reset password token.  This token is sent via email if the user triggers the PATCH `/api/user/forgotpassword` endpoint and includes a valid email address.

This is the second step to address issue #25 and should complete the API work.