### PR TITLE
Add ForgotPassword cmp and client side route

### DIFF
--- a/packages/api-postgres/src/user/UserController.ts
+++ b/packages/api-postgres/src/user/UserController.ts
@@ -196,7 +196,7 @@ class UserController {
                     success: true,
                     message: 'password reset instructions sent to user email',
                     payload: {
-                        user: user.toClientJSON()
+                        email: user.email
                     }
                 });
             }
@@ -205,7 +205,7 @@ class UserController {
                 success: false,
                 message: 'user not found',
                 payload: {
-                    user: null
+                    email: null
                 }
             });
         });

--- a/packages/api-postgres/src/user/__tests__/user.acceptance-test.ts
+++ b/packages/api-postgres/src/user/__tests__/user.acceptance-test.ts
@@ -420,7 +420,7 @@ describe('User route acceptance tests', () => {
                         success: true,
                         message: 'password reset instructions sent to user email',
                         payload: expect.objectContaining({
-                            user: expect.any(Object)
+                            email: 'oliver@desc.org'
                         })
                     })
                 );
@@ -434,7 +434,7 @@ describe('User route acceptance tests', () => {
                         success: false,
                         message: 'user not found',
                         payload: expect.objectContaining({
-                            user: null
+                            email: null
                         })
                     })
                 );

--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -13,6 +13,7 @@ import RequestCreationPage from './components/RequestCreation/RequestCreationPag
 import Request from './containers/Request';
 import Home from './components/Home';
 import ConfirmEmail from './containers/ConfirmEmail';
+import ForgotPassword from './containers/ForgotPassword';
 import PrivateRoute from './components/PrivateRoute';
 import { reducer } from './reducers/reducer';
 
@@ -30,6 +31,7 @@ function App() {
                         <Route exact path="/" component={Home} />
                         <Route exact path="/signup" component={Signup} />
                         <Route exact path="/signin" component={Signin} />
+                        <Route exact path="/forgotpassword" component={ForgotPassword} />
                         <Route exact path="/confirmemail/:token" component={ConfirmEmail} />
 
                         <PrivateRoute exact path="/inbox" component={Inbox} />

--- a/packages/app/src/components/ForgotPasswordForm/ForgotPasswordForm.js
+++ b/packages/app/src/components/ForgotPasswordForm/ForgotPasswordForm.js
@@ -1,0 +1,130 @@
+import React, { useState, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+import M from 'materialize-css';
+import TextField from '../Common/TextField';
+import { forgotPassword } from '../../services/users';
+
+const css = {
+    formContainer: {
+        padding: '1.5rem 2rem',
+        maxWidth: '670px',
+        margin: '2.5rem auto 0'
+    },
+
+    errorText: {
+        padding: '0 4rem',
+        fontSize: '1rem'
+    },
+
+    cancelButton: {
+        backgroundColor: 'white',
+        color: 'teal',
+        marginRight: '1rem'
+    },
+
+    message: {
+        marginTop: '2rem',
+        fontSize: '1.25rem'
+    }
+};
+
+const ForgotPasswordForm = () => {
+    const history = useHistory();
+
+    const [isRequestSent, setIsRequestSent] = useState(false);
+    const [email, setEmail] = useState('');
+    const [formValue, setFormValue] = useState('');
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        setFormValue(v => '');
+        setTimeout(() => {
+            M.updateTextFields();
+        }, 500);
+    }, [email]);
+
+    const handleSubmit = e => {
+        e.preventDefault();
+        if (formValue.length > 0) {
+            forgotPassword(formValue).then(data => {
+                if (data.success) {
+                    setEmail(data.payload.email);
+                    setIsRequestSent(true);
+                } else {
+                    setError('Something went wrong. Please try again.');
+                }
+            });
+        }
+    };
+
+    const handleCancel = () => {
+        history.push('/');
+    };
+
+    const handleChange = e => {
+        setFormValue(e.target.value);
+    };
+
+    return (
+        <div className="card-panel" style={css.formContainer}>
+            <h4 className="center-align teal-text text-darken-3">Reset Password</h4>
+            <p className="grey-text text-darken-1" style={{ fontSize: '1.25rem' }}>
+                Enter the email address associated with your account and we'll send you a link to
+                reset your password.
+            </p>
+            <form onSubmit={handleSubmit}>
+                <div className="row">
+                    <div className="col s12">
+                        <TextField
+                            label="Your Email"
+                            icon="email"
+                            type="text"
+                            name="email"
+                            value={formValue}
+                            handleChange={handleChange}
+                            validate
+                        />
+                    </div>
+                </div>
+                <div className="row">
+                    {error.length > 0 && (
+                        <p className="red-text" style={css.errorText} data-testid="error-message">
+                            {error}
+                        </p>
+                    )}
+                </div>
+                <div className="row">
+                    <div className="col right">
+                        <button
+                            className="btn"
+                            type="button"
+                            onClick={handleCancel}
+                            style={css.cancelButton}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            className="waves-effect waves-light btn"
+                            type="submit"
+                            data-testid="submit-btn"
+                        >
+                            Reset Password
+                        </button>
+                    </div>
+                </div>
+            </form>
+            {isRequestSent && (
+                <p
+                    className="teal-text text-darken-3"
+                    style={css.message}
+                    data-testid="success-message"
+                >
+                    Thank you. An email has been sent to <em>{`${email}`}</em> with instructions to
+                    reset your password.
+                </p>
+            )}
+        </div>
+    );
+};
+
+export default ForgotPasswordForm;

--- a/packages/app/src/components/ForgotPasswordForm/ForgotPasswordForm.test.js
+++ b/packages/app/src/components/ForgotPasswordForm/ForgotPasswordForm.test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render, cleanup, fireEvent, waitForElement } from '@testing-library/react';
+import ForgotPasswordForm from './ForgotPasswordForm';
+import * as UserDataService from '../../services/users';
+
+jest.mock('../../services/users');
+
+describe('Forgotpassword Form', () => {
+    afterEach(cleanup);
+
+    it('renders an input for email', () => {
+        const { getByLabelText } = render(
+            <MemoryRouter>
+                <ForgotPasswordForm />
+            </MemoryRouter>
+        );
+        expect(getByLabelText('Your Email')).toBeTruthy();
+    });
+
+    it('displays message to user if the API call is successful', async () => {
+        const json = Promise.resolve({
+            success: true,
+            message: 'password details sent to user',
+            payload: { user: 'some@email.com' }
+        });
+
+        UserDataService.forgotPassword = jest.fn(() => json);
+
+        const { getByLabelText, getByTestId, container } = render(
+            <MemoryRouter>
+                <ForgotPasswordForm />
+            </MemoryRouter>
+        );
+        const emailInput = getByLabelText('Your Email');
+        fireEvent.change(emailInput, { target: { value: 'some@email.com' } });
+        fireEvent.click(getByTestId('submit-btn'));
+
+        const message = await waitForElement(() => getByTestId('success-message'), { container });
+        expect(message.textContent).toContain('Thank you.');
+        expect(UserDataService.forgotPassword).toHaveBeenCalledWith('some@email.com');
+    });
+
+    it('displays error message if the API call is unsuccessful', async () => {
+        const json = Promise.resolve({
+            success: false,
+            message: 'user not found',
+            payload: { user: null }
+        });
+
+        UserDataService.forgotPassword = jest.fn(() => json);
+
+        const { getByLabelText, getByTestId, container } = render(
+            <MemoryRouter>
+                <ForgotPasswordForm />
+            </MemoryRouter>
+        );
+        const emailInput = getByLabelText('Your Email');
+        fireEvent.change(emailInput, { target: { value: 'unknown-user@email.com' } });
+        fireEvent.click(getByTestId('submit-btn'));
+
+        const message = await waitForElement(() => getByTestId('error-message'), { container });
+        expect(message.textContent).toContain('Something went wrong.');
+        expect(UserDataService.forgotPassword).toHaveBeenCalledWith('unknown-user@email.com');
+    });
+});

--- a/packages/app/src/components/SigninForm/SigninForm.js
+++ b/packages/app/src/components/SigninForm/SigninForm.js
@@ -1,4 +1,5 @@
 import React, { useState, useContext } from 'react';
+import { Link } from 'react-router-dom';
 import M from 'materialize-css';
 import AuthContext from '../../context/AuthContext';
 import TextField from '../Common/TextField';
@@ -12,6 +13,11 @@ const css = {
     },
 
     errorText: {
+        padding: '0 4rem',
+        fontSize: '1rem'
+    },
+
+    forgotPassword: {
         padding: '0 4rem',
         fontSize: '1rem'
     },
@@ -108,11 +114,13 @@ const SigninForm = ({ history }) => {
                         />
                     </div>
                 </div>
-                <div className="row">
-                    <p className="red-text" style={css.errorText}>
-                        {form.errorMsg}
-                    </p>
-                </div>
+                {form.errorMsg.length > 0 && (
+                    <div className="row">
+                        <p className="red-text" style={css.errorText}>
+                            {form.errorMsg}
+                        </p>
+                    </div>
+                )}
                 <div className="row">
                     <div className="col right">
                         <button
@@ -127,6 +135,11 @@ const SigninForm = ({ history }) => {
                             {`${!isFetching ? 'Sign In' : 'Signing In...'}`}
                         </button>
                     </div>
+                </div>
+                <div className="row">
+                    <Link to="/forgotpassword" className="teal-text" style={css.forgotPassword}>
+                        Forgot Password?
+                    </Link>
                 </div>
             </form>
         </div>

--- a/packages/app/src/components/SigninForm/SigninForm.test.js
+++ b/packages/app/src/components/SigninForm/SigninForm.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, cleanup, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import SigninForm from './SigninForm';
 import { AuthProvider } from '../../context/AuthContext';
 import * as Auth from '../../services/auth';
@@ -14,12 +15,20 @@ describe('SigninForm', () => {
     afterEach(cleanup);
 
     it('renders an input for email', () => {
-        const { getByLabelText } = render(<SigninForm />);
+        const { getByLabelText } = render(
+            <MemoryRouter>
+                <SigninForm />{' '}
+            </MemoryRouter>
+        );
         expect(getByLabelText('Your Email')).toBeTruthy();
     });
 
     it('renders an input for password', () => {
-        const { getByLabelText } = render(<SigninForm />);
+        const { getByLabelText } = render(
+            <MemoryRouter>
+                <SigninForm />{' '}
+            </MemoryRouter>
+        );
         expect(getByLabelText('Password')).toBeTruthy();
     });
 
@@ -29,9 +38,11 @@ describe('SigninForm', () => {
             .mockResolvedValue({ success: true, message: 'User authenticated', payload: {} });
 
         const { getByLabelText, getByText } = render(
-            <AuthProvider value={{ login: () => {} }}>
-                <SigninForm history={history} />
-            </AuthProvider>
+            <MemoryRouter>
+                <AuthProvider value={{ login: () => {} }}>
+                    <SigninForm history={history} />
+                </AuthProvider>
+            </MemoryRouter>
         );
         const emailInput = getByLabelText('Your Email');
         const passwordInput = getByLabelText('Password');

--- a/packages/app/src/containers/ForgotPassword.js
+++ b/packages/app/src/containers/ForgotPassword.js
@@ -1,0 +1,16 @@
+import React, { useContext } from 'react';
+import { Redirect } from 'react-router-dom';
+import AuthContext from '../context/AuthContext';
+import ForgotPasswordForm from '../components/ForgotPasswordForm/ForgotPasswordForm';
+
+const ForgotPassword = () => {
+    const authCtx = useContext(AuthContext);
+
+    if (authCtx.contextUser) {
+        return <Redirect to="/" />;
+    }
+
+    return <ForgotPasswordForm />;
+};
+
+export default ForgotPassword;

--- a/packages/app/src/services/users.js
+++ b/packages/app/src/services/users.js
@@ -23,3 +23,15 @@ export const confirmEmail = token => {
         }
     });
 };
+
+export const forgotPassword = email => {
+    return fetch(`${BASE_URL}/api/users/forgotpassword`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+    }).then(res => {
+        if (res.ok && res.status === 200) {
+            return res.json();
+        }
+    });
+};


### PR DESCRIPTION
This is an interim PR to add a 'ForgotPassword' component, which will provide an input to the user to enter their password to initiate the self-service flow to reset the password.  Once the user submits their email address, an automated email will be sent to their email address that contains instructions to reset their password.  This email includes a one-time token that is only valid for 2hrs.

This is the third step to address issue #25 and is the first of the client-side work.