### PR TITLE
Add ChangePassword cmp and client-side route

### DIFF
--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -14,6 +14,7 @@ import Request from './containers/Request';
 import Home from './components/Home';
 import ConfirmEmail from './containers/ConfirmEmail';
 import ForgotPassword from './containers/ForgotPassword';
+import ChangePassword from './containers/ChangePassword';
 import PrivateRoute from './components/PrivateRoute';
 import { reducer } from './reducers/reducer';
 
@@ -33,6 +34,7 @@ function App() {
                         <Route exact path="/signin" component={Signin} />
                         <Route exact path="/forgotpassword" component={ForgotPassword} />
                         <Route exact path="/confirmemail/:token" component={ConfirmEmail} />
+                        <Route exact path="/changepassword/:token" component={ChangePassword} />
 
                         <PrivateRoute exact path="/inbox" component={Inbox} />
                         <PrivateRoute exact path="/createv1" component={RequestCreationPage} />

--- a/packages/app/src/components/ChangePasswordForm/ChangePasswordForm.js
+++ b/packages/app/src/components/ChangePasswordForm/ChangePasswordForm.js
@@ -1,0 +1,142 @@
+import React, { useEffect, useState } from 'react';
+import M from 'materialize-css';
+import { useHistory } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import TextField from '../Common/TextField';
+import { changePassword } from '../../services/users';
+
+const css = {
+    formContainer: {
+        padding: '1.5rem 2rem',
+        maxWidth: '670px',
+        margin: '2.5rem auto 0'
+    },
+    cancelButton: {
+        backgroundColor: 'white',
+        color: 'teal',
+        marginRight: '1rem'
+    }
+};
+
+const ChangePasswordForm = () => {
+    const { token } = useParams();
+    const history = useHistory();
+
+    const [isFetching, setIsFetching] = useState(false);
+    const [error, setError] = useState(null);
+
+    const [form, setForm] = useState({
+        password: '',
+        confirmPassword: ''
+    });
+
+    useEffect(() => {
+        if (form.confirmPassword.length > 0 && form.password !== form.confirmPassword) {
+            setError('Passwords do NOT match');
+        }
+        if (form.confirmPassword.length > 0 && form.password === form.confirmPassword) {
+            setError(null);
+        }
+        if (form.password.length > 0 && form.confirmPassword.length === 0) {
+            setError(null);
+        }
+    }, [form]);
+
+    const handleSubmit = e => {
+        e.preventDefault();
+
+        if (isFormValid()) {
+            setIsFetching(true);
+            changePassword(token, form.password)
+                .then(data => {
+                    if (data.success) {
+                        setError(null);
+                        M.toast({
+                            html: 'Your password has been changed',
+                            classes: 'teal',
+                            displayLength: 3000,
+                            completeCallback: () => {
+                                history.push('/signin');
+                            }
+                        });
+                    } else {
+                        setError('Something went wrong; password not changed');
+                    }
+                    setForm({ password: '', confirmPassword: '' });
+                    setIsFetching(false);
+                })
+                .catch(err => console.log(err));
+        } else {
+            setError('Password is not provided. Try again');
+        }
+    };
+
+    const handleChange = e => {
+        setForm({
+            ...form,
+            [e.target.id]: e.target.value
+        });
+    };
+
+    const isFormValid = () => {
+        return form.password.length > 0 && form.password === form.confirmPassword;
+    };
+    const handleCancel = () => {
+        history.push('/');
+    };
+
+    return (
+        <div className="card-panel" style={css.formContainer}>
+            <h4 className="center-align teal-text text-darken-3">Change Password</h4>
+            <form onSubmit={handleSubmit}>
+                <div className="row">
+                    <div className="col s12">
+                        <TextField
+                            label="Password"
+                            icon="lock"
+                            type="password"
+                            name="password"
+                            value={form.password}
+                            handleChange={handleChange}
+                        />
+                    </div>
+                </div>
+                <div className="row">
+                    <div className="col s12">
+                        <TextField
+                            label="Confirm Password"
+                            icon="lock"
+                            type="password"
+                            name="confirmPassword"
+                            value={form.confirmPassword}
+                            error={error}
+                            handleChange={handleChange}
+                        />
+                    </div>
+                </div>
+
+                <div className="row">
+                    <div className="col right">
+                        <button
+                            className="btn"
+                            type="button"
+                            onClick={handleCancel}
+                            style={css.cancelButton}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            className="waves-effect waves-light btn"
+                            type="submit"
+                            data-testid="submit-btn"
+                        >
+                            {`${!isFetching ? 'Change Password' : 'Changing Password...'}`}
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    );
+};
+
+export default ChangePasswordForm;

--- a/packages/app/src/components/ChangePasswordForm/ChangePasswordForm.test.js
+++ b/packages/app/src/components/ChangePasswordForm/ChangePasswordForm.test.js
@@ -1,0 +1,123 @@
+import React from 'react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { render, cleanup, fireEvent, waitForElement } from '@testing-library/react';
+import ChangePasswordForm from './ChangePasswordForm';
+import * as UserDataService from '../../services/users';
+
+jest.mock('../../services/users');
+
+const token = '40a2be43-8628-4c4e-a31c-af755e105330';
+
+describe('ChangePassword Form', () => {
+    afterEach(cleanup);
+
+    it('renders an input for the new password', () => {
+        const { getByLabelText } = render(
+            <MemoryRouter>
+                <ChangePasswordForm />
+            </MemoryRouter>
+        );
+        expect(getByLabelText('Password')).toBeTruthy();
+    });
+
+    it('renders an input to confirm new password', () => {
+        const { getByLabelText } = render(
+            <MemoryRouter>
+                <ChangePasswordForm />
+            </MemoryRouter>
+        );
+        expect(getByLabelText('Confirm Password')).toBeTruthy();
+    });
+
+    it('does not display message if password fields match', () => {
+        const { getByLabelText, queryByText } = render(
+            <MemoryRouter>
+                <ChangePasswordForm />
+            </MemoryRouter>
+        );
+
+        const passwordInput = getByLabelText('Password');
+        const confirmPasswordInput = getByLabelText('Confirm Password');
+        fireEvent.change(passwordInput, { target: { value: 'correctpassword' } });
+        fireEvent.change(confirmPasswordInput, { target: { value: 'correctpassword' } });
+
+        expect(queryByText('Passwords do NOT match')).toBe(null);
+    });
+
+    it('displays a message when the password fields do not match', () => {
+        const { getByLabelText, getByText } = render(
+            <MemoryRouter>
+                <ChangePasswordForm />
+            </MemoryRouter>
+        );
+
+        const passwordInput = getByLabelText('Password');
+        const confirmPasswordInput = getByLabelText('Confirm Password');
+        fireEvent.change(passwordInput, { target: { value: 'correctpassword' } });
+        fireEvent.change(confirmPasswordInput, { target: { value: 'incorrectpassword' } });
+
+        expect(getByText('Passwords do NOT match')).toBeTruthy();
+    });
+
+    it('displays a toast message if the password is changed', async () => {
+        const json = Promise.resolve({
+            success: true,
+            message: 'password changed',
+            payload: { user: {} }
+        });
+
+        UserDataService.changePassword = jest.fn(() => json);
+
+        const { container, getByLabelText, getByText, getByTestId } = render(
+            <MemoryRouter initialEntries={[`/changepassword/${token}`]}>
+                <Route path="/changepassword/:token">
+                    <ChangePasswordForm />
+                </Route>
+            </MemoryRouter>
+        );
+
+        const passwordInput = getByLabelText('Password');
+        const confirmPasswordInput = getByLabelText('Confirm Password');
+        fireEvent.change(passwordInput, { target: { value: 'correctpassword' } });
+        fireEvent.change(confirmPasswordInput, { target: { value: 'correctpassword' } });
+        fireEvent.click(getByTestId('submit-btn'));
+
+        const toast = await waitForElement(() => getByText('Your password has been changed'), {
+            container
+        });
+        expect(toast).toBeTruthy();
+        expect(UserDataService.changePassword).toHaveBeenCalledTimes(1);
+        expect(UserDataService.changePassword).toHaveBeenCalledWith(token, 'correctpassword');
+    });
+
+    it('displays a message if the password is not changed', async () => {
+        const json = Promise.resolve({
+            success: false,
+            message: 'password not changed',
+            payload: { user: null }
+        });
+
+        UserDataService.changePassword = jest.fn(() => json);
+
+        const { container, getByLabelText, getByText, getByTestId } = render(
+            <MemoryRouter initialEntries={[`/changepassword/${token}`]}>
+                <Route path="/changepassword/:token">
+                    <ChangePasswordForm />
+                </Route>
+            </MemoryRouter>
+        );
+
+        const passwordInput = getByLabelText('Password');
+        const confirmPasswordInput = getByLabelText('Confirm Password');
+        fireEvent.change(passwordInput, { target: { value: 'correctpassword' } });
+        fireEvent.change(confirmPasswordInput, { target: { value: 'correctpassword' } });
+        fireEvent.click(getByTestId('submit-btn'));
+
+        const message = await waitForElement(() => getByText(/Something went wrong/i), {
+            container
+        });
+        expect(message).toBeTruthy();
+        expect(UserDataService.changePassword).toHaveBeenCalledTimes(1);
+        expect(UserDataService.changePassword).toHaveBeenCalledWith(token, 'correctpassword');
+    });
+});

--- a/packages/app/src/containers/ChangePassword.js
+++ b/packages/app/src/containers/ChangePassword.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import ChangePasswordForm from '../components/ChangePasswordForm/ChangePasswordForm';
+
+const ChangePassword = () => {
+    return <ChangePasswordForm />;
+};
+
+export default ChangePassword;

--- a/packages/app/src/services/users.js
+++ b/packages/app/src/services/users.js
@@ -35,3 +35,15 @@ export const forgotPassword = email => {
         }
     });
 };
+
+export const changePassword = (token, newPassword) => {
+    return fetch(`${BASE_URL}/api/users/changepassword/${token}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ newPassword })
+    }).then(res => {
+        if (res.ok && res.status === 200) {
+            return res.json();
+        }
+    });
+};


### PR DESCRIPTION
This is an interim PR to add a 'ChangePassword' component, which will provide a form for the user to enter and confirm their new password.  This new component is rendered when the user comes to the app via the link in the email that is sent to them when they request a password reset.  This url will include the unique token to authorize them to change their password.

This is the final step to address issue #25 