### PR TITLE
Remove valid class from text field after API call

### DIFF
--- a/packages/app/src/components/Common/TextField.js
+++ b/packages/app/src/components/Common/TextField.js
@@ -1,10 +1,14 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
-const TextField = ({ type, name, label, validate, value, error, icon, disabled, handleChange }) => {
+const TextField = (
+    { type, name, label, validate, value, error, icon, disabled, handleChange },
+    ref
+) => {
     return (
         <div className="input-field">
             {icon && <i className="small material-icons prefix">{icon}</i>}
             <input
+                ref={ref}
                 className={validate ? 'validate' : ''}
                 type={type}
                 id={name}
@@ -18,14 +22,4 @@ const TextField = ({ type, name, label, validate, value, error, icon, disabled, 
     );
 };
 
-TextField.defaultProps = {
-    type: 'text',
-    name: 'unknown',
-    label: 'Text Label',
-    validat: false,
-    value: '',
-    icon: '',
-    handleChange: () => {}
-};
-
-export default TextField;
+export default forwardRef(TextField);

--- a/packages/app/src/components/ForgotPasswordForm/ForgotPasswordForm.js
+++ b/packages/app/src/components/ForgotPasswordForm/ForgotPasswordForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import M from 'materialize-css';
 import TextField from '../Common/TextField';
@@ -30,6 +30,7 @@ const css = {
 
 const ForgotPasswordForm = () => {
     const history = useHistory();
+    const textFieldRef = useRef();
 
     const [isRequestSent, setIsRequestSent] = useState(false);
     const [email, setEmail] = useState('');
@@ -40,7 +41,8 @@ const ForgotPasswordForm = () => {
         setFormValue(v => '');
         setTimeout(() => {
             M.updateTextFields();
-        }, 500);
+            textFieldRef.current.classList.remove('valid');
+        }, 250);
     }, [email]);
 
     const handleSubmit = e => {
@@ -76,6 +78,7 @@ const ForgotPasswordForm = () => {
                 <div className="row">
                     <div className="col s12">
                         <TextField
+                            ref={textFieldRef}
                             label="Your Email"
                             icon="email"
                             type="text"


### PR DESCRIPTION
Add a 'forward ref' to the TextField component in order to remove the `valid` class from the input field to reset the styling after the user's email is successfully sent via the API.