### PR TITLE
Add self-service password reset functionality

### DIFF
--- a/packages/api-postgres/src/common/DateUtils.ts
+++ b/packages/api-postgres/src/common/DateUtils.ts
@@ -1,0 +1,19 @@
+/**
+ * Date utility class
+ *
+ * The intent of this class is to provide better control over the expiration times of
+ * tokens which is especially useful for testing.
+ */
+class DateUtils {
+    static ONE_MINUTE_IN_MS = 60 * 1000;
+
+    public static getCurrentDateTime(): Date {
+        return new Date();
+    }
+
+    public static getDateMinutesFromNow(minutes: number): Date {
+        return new Date(Date.now() + minutes * DateUtils.ONE_MINUTE_IN_MS);
+    }
+}
+
+export default DateUtils;

--- a/packages/api-postgres/src/entity/User.ts
+++ b/packages/api-postgres/src/entity/User.ts
@@ -58,6 +58,9 @@ export default class User extends BaseEntity {
     @Column({ default: new Date() })
     passwordResetTokenExpiresAt: Date;
 
+    @Column({ default: new Date() })
+    passwordLastChangedAt: Date;
+
     @Column({ nullable: true })
     lastLoginAt: Date;
 

--- a/packages/api-postgres/src/mailer/Mailer.ts
+++ b/packages/api-postgres/src/mailer/Mailer.ts
@@ -4,6 +4,10 @@ import {
     getEmailVerificatonTemplateText,
     getEmailVerificatonTemplateHTML
 } from './templates/emailVerificaton';
+import {
+    getPasswordResetTemplateHTML,
+    getPasswordResetTemplateText
+} from './templates/passwordReset';
 
 interface MailOptions {
     port?: number;
@@ -25,6 +29,24 @@ class Mailer {
                 subject: 'DESC In-Kind Portal Email Verification',
                 text: getEmailVerificatonTemplateText(baseUrl, user.emailVerificationToken),
                 html: getEmailVerificatonTemplateHTML(baseUrl, user.emailVerificationToken)
+            });
+        }
+    }
+
+    public static async sendPasswordResetEmail(baseUrl: string, user: User): Promise<any> {
+        const transporter = nodemailer.createTransport(Mailer.getMailOptions());
+        const verifiedTransporter =
+            process.env.NODE_ENV === 'testingE2E' || process.env.NODE_ENV === 'testing'
+                ? true
+                : await transporter.verify();
+
+        if (verifiedTransporter) {
+            return transporter.sendMail({
+                from: 'portal-admin@desc.org',
+                to: user.email,
+                subject: 'DESC In-Kind Password Reset',
+                text: getPasswordResetTemplateText(baseUrl, user.passwordResetToken),
+                html: getPasswordResetTemplateHTML(baseUrl, user.passwordResetToken)
             });
         }
     }

--- a/packages/api-postgres/src/mailer/__tests__/Mailer.test.ts
+++ b/packages/api-postgres/src/mailer/__tests__/Mailer.test.ts
@@ -14,4 +14,17 @@ describe('Mailer', () => {
             })
         );
     });
+
+    it('sends password reset email', async () => {
+        const testUser = new User();
+        testUser.passwordResetToken = 'randomtokenstringhere';
+        const email = await Mailer.sendPasswordResetEmail('http://localhost:3001', testUser);
+
+        expect(email).toEqual(
+            expect.objectContaining({
+                envelope: expect.any(Object),
+                messageId: expect.any(String)
+            })
+        );
+    });
 });

--- a/packages/api-postgres/src/mailer/templates/passwordReset.ts
+++ b/packages/api-postgres/src/mailer/templates/passwordReset.ts
@@ -1,0 +1,39 @@
+import { styles } from './common';
+
+export function getPasswordResetTemplateHTML(baseUrl: string, token: string): string {
+    return `
+${styles}
+<div class="container">
+    <div class="banner">
+        <p>Password Reset</p>
+    </div>
+    <p class="text">
+        You recently requested to reset your password for the DESC In-Kind Portal. If you did not initiate this request,
+        no action is required.  If you did, then you will need to click on the link below and change your password when
+        redirected to the "Change Password" form.  This link is only valid for the next 2 hours.
+    </p>
+    <a class="btn" href="${baseUrl}/changepassword/${token}">Password Reset</a>
+    <p class="text">or click on the below link:</p>
+    <p class="text"><a href="${baseUrl}/confirmemail/${token}">${baseUrl}/changepassword/${token}</a></p>
+    <p class="text">If you did not request a password reset for your DESC In-Kind Portal account, please disregard this email.</p>
+    <p class="text">Thank you!</p>
+    <p class="text">&mdash; The DESC In-Kind Portal Team</p>
+</div>
+<p class="footer">&copy; 2020 &bull; All Rights Reserved &bull; Downtown Emergency Service Center</p>
+`;
+}
+
+export function getPasswordResetTemplateText(baseUrl: string, token: string): string {
+    return `
+You recently requested to reset your password for the DESC In-Kind Portal. If you did not initiate this request,
+no action is required.  If you did, then you will need to click on the link below and change your password when
+redirected to the "Change Password" form.  This link is only valid for the next 2 hours.
+
+    ${baseUrl}/changepassword/${token}
+
+If you did not request a password reset for your DESC In-Kind Portal account, please disregard this email.
+
+Thank you!
+-- The DESC In-Kind Portal Team
+`;
+}

--- a/packages/api-postgres/src/testUtils/TestClient.ts
+++ b/packages/api-postgres/src/testUtils/TestClient.ts
@@ -90,6 +90,13 @@ class TestClient extends BaseTestClient {
             .send({ email });
     }
 
+    public changePassword(token: string, newPassword: string): Test {
+        return request(this.app)
+            .patch(`/api/users/changepassword/${token}`)
+            .set('Content-Type', 'application/json')
+            .send({ newPassword });
+    }
+
     public createItem(itemData: any): Test {
         return request(this.app)
             .post('/api/items')

--- a/packages/api-postgres/src/testUtils/TestClient.ts
+++ b/packages/api-postgres/src/testUtils/TestClient.ts
@@ -83,6 +83,13 @@ class TestClient extends BaseTestClient {
             .set('Content-Type', 'application/json');
     }
 
+    public forgotPassword(email: string): Test {
+        return request(this.app)
+            .patch(`/api/users/forgotpassword`)
+            .set('Content-Type', 'application/json')
+            .send({ email });
+    }
+
     public createItem(itemData: any): Test {
         return request(this.app)
             .post('/api/items')

--- a/packages/api-postgres/src/user/UserController.ts
+++ b/packages/api-postgres/src/user/UserController.ts
@@ -211,6 +211,40 @@ class UserController {
         });
     }
 
+    static changePassword(req: Request, res: Response): Promise<Response> {
+        const resetToken = req.params.token;
+        const { newPassword } = req.body;
+        return UserService.changePassword(resetToken, newPassword)
+            .then((user) => {
+                if (user) {
+                    return res.json({
+                        success: true,
+                        message: 'password changed',
+                        payload: {
+                            user: user.toClientJSON()
+                        }
+                    });
+                } else {
+                    return res.json({
+                        success: false,
+                        message: 'password not changed',
+                        payload: {
+                            user: null
+                        }
+                    });
+                }
+            })
+            .catch(() => {
+                return res.json({
+                    success: false,
+                    message: 'error with reset token',
+                    payload: {
+                        user: null
+                    }
+                });
+            });
+    }
+
     static async me(req: Request, res: Response): Promise<Response> {
         const baseResponse = {
             success: true,

--- a/packages/api-postgres/src/user/UserController.ts
+++ b/packages/api-postgres/src/user/UserController.ts
@@ -196,7 +196,7 @@ class UserController {
                     success: true,
                     message: 'password reset instructions sent to user email',
                     payload: {
-                        user: user.toClientJSON()
+                        email: user.email
                     }
                 });
             }
@@ -205,7 +205,7 @@ class UserController {
                 success: false,
                 message: 'user not found',
                 payload: {
-                    user: null
+                    email: null
                 }
             });
         });

--- a/packages/api-postgres/src/user/UserController.ts
+++ b/packages/api-postgres/src/user/UserController.ts
@@ -185,6 +185,32 @@ class UserController {
             });
     }
 
+    static forgotPassword(req: Request, res: Response): Promise<Response> {
+        const { email } = req.body;
+        return UserService.generatePasswordResetToken(email).then(async (user) => {
+            if (user) {
+                const baseUrl = (req.get('origin') as string) || '';
+                await Mailer.sendPasswordResetEmail(baseUrl, user);
+
+                return res.json({
+                    success: true,
+                    message: 'password reset instructions sent to user email',
+                    payload: {
+                        user: user.toClientJSON()
+                    }
+                });
+            }
+
+            return res.json({
+                success: false,
+                message: 'user not found',
+                payload: {
+                    user: null
+                }
+            });
+        });
+    }
+
     static async me(req: Request, res: Response): Promise<Response> {
         const baseResponse = {
             success: true,

--- a/packages/api-postgres/src/user/UserRouter.ts
+++ b/packages/api-postgres/src/user/UserRouter.ts
@@ -26,13 +26,13 @@ class UserRouter {
     }
 
     private static defineRoutes(): void {
-        UserRouter.router.route('/me').get(checkForRefreshToken, UserController.me);
-        UserRouter.router.route('/forgotpassword').patch(UserController.forgotPassword);
-
         UserRouter.router
             .route('/')
             .post(UserController.createUser)
             .get(isAdmin, UserController.getAllUsers);
+
+        UserRouter.router.route('/me').get(checkForRefreshToken, UserController.me);
+        UserRouter.router.route('/forgotpassword').patch(UserController.forgotPassword);
 
         UserRouter.router
             .route('/:id([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})')
@@ -41,6 +41,7 @@ class UserRouter {
             .delete(isAdminOrSelf, UserController.deleteUser);
 
         UserRouter.router.route('/confirmemail/:token').patch(UserController.confirmEmail);
+        UserRouter.router.route('/changepassword/:token').patch(UserController.changePassword);
     }
 }
 

--- a/packages/api-postgres/src/user/UserRouter.ts
+++ b/packages/api-postgres/src/user/UserRouter.ts
@@ -27,6 +27,7 @@ class UserRouter {
 
     private static defineRoutes(): void {
         UserRouter.router.route('/me').get(checkForRefreshToken, UserController.me);
+        UserRouter.router.route('/forgotpassword').patch(UserController.forgotPassword);
 
         UserRouter.router
             .route('/')
@@ -34,7 +35,7 @@ class UserRouter {
             .get(isAdmin, UserController.getAllUsers);
 
         UserRouter.router
-            .route('/:id')
+            .route('/:id([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})')
             .get(isAdminOrSelf, UserController.getUser)
             .patch(isAdminOrSelf, UserController.updateUser)
             .delete(isAdminOrSelf, UserController.deleteUser);

--- a/packages/api-postgres/src/user/UserService.ts
+++ b/packages/api-postgres/src/user/UserService.ts
@@ -72,6 +72,17 @@ export default class UserService {
         });
     }
 
+    static async generatePasswordResetToken(email: string): Promise<User | undefined> {
+        const user = await UserService.getUserByEmail(email);
+        if (user) {
+            const in2hrs = new Date(Date.now() + 120 * 1000 * 60);
+            user.passwordResetToken = v4();
+            user.passwordResetTokenExpiresAt = in2hrs;
+            await user.save();
+        }
+        return user;
+    }
+
     private static async getUserCount(): Promise<number> {
         const count = await getRepository(User).createQueryBuilder('user').getCount();
         return count;

--- a/packages/api-postgres/src/user/__tests__/UserService.test.ts
+++ b/packages/api-postgres/src/user/__tests__/UserService.test.ts
@@ -191,4 +191,36 @@ describe('User service integration tests', () => {
             expect(result?.emailVerificationToken).toBe('');
         });
     });
+
+    describe('generatePasswordResetToken method', () => {
+        let userEmail: string;
+
+        beforeEach(async () => {
+            const { firstName, lastName, email, password, program } = testUser;
+            const user = await UserService.createUser({
+                firstName,
+                lastName,
+                email,
+                password,
+                program
+            });
+
+            userEmail = user.email;
+        });
+
+        afterEach(async () => {
+            await TestUtils.dropUsers();
+        });
+
+        it('returns undefined if user cannot be found with given email', async () => {
+            const result = await UserService.generatePasswordResetToken('unknown-user@test.com');
+            expect(result).toBeUndefined();
+        });
+
+        it('generates random token to use for password reset', async () => {
+            const result = await UserService.generatePasswordResetToken(userEmail);
+            expect(result?.passwordResetToken.length).toBeGreaterThan(0);
+            expect(result?.passwordResetTokenExpiresAt instanceof Date).toBeTruthy();
+        });
+    });
 });

--- a/packages/api-postgres/src/user/__tests__/user.acceptance-test.ts
+++ b/packages/api-postgres/src/user/__tests__/user.acceptance-test.ts
@@ -420,7 +420,7 @@ describe('User route acceptance tests', () => {
                         success: true,
                         message: 'password reset instructions sent to user email',
                         payload: expect.objectContaining({
-                            user: expect.any(Object)
+                            email: 'oliver@desc.org'
                         })
                     })
                 );
@@ -434,7 +434,7 @@ describe('User route acceptance tests', () => {
                         success: false,
                         message: 'user not found',
                         payload: expect.objectContaining({
-                            user: null
+                            email: null
                         })
                     })
                 );

--- a/packages/api-postgres/src/user/__tests__/user.acceptance-test.ts
+++ b/packages/api-postgres/src/user/__tests__/user.acceptance-test.ts
@@ -388,4 +388,56 @@ describe('User route acceptance tests', () => {
             });
         });
     });
+
+    describe('/api/users/forgotpassword route', () => {
+        let client: TestClient;
+
+        beforeAll(() => {
+            client = new TestClient();
+        });
+
+        afterEach(async () => {
+            await TestUtils.dropUsers();
+        });
+
+        beforeEach(async () => {
+            await TestUtils.createTestUser({
+                firstName: 'Oliver',
+                lastName: 'Queen',
+                email: 'oliver@desc.org',
+                password: '123456',
+                program: Program.SURVIVAL
+            });
+        });
+
+        describe('PATCH request method', () => {
+            it('sends password reset email to user', async () => {
+                const response = await client.forgotPassword('oliver@desc.org');
+
+                expect(response.body).toEqual(
+                    expect.objectContaining({
+                        success: true,
+                        message: 'password reset instructions sent to user email',
+                        payload: expect.objectContaining({
+                            user: expect.any(Object)
+                        })
+                    })
+                );
+            });
+
+            it('returns a null user if the user (email) is not found', async () => {
+                const response = await client.forgotPassword('unknownemail@desc.org');
+
+                expect(response.body).toEqual(
+                    expect.objectContaining({
+                        success: false,
+                        message: 'user not found',
+                        payload: expect.objectContaining({
+                            user: null
+                        })
+                    })
+                );
+            });
+        });
+    });
 });

--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -14,6 +14,7 @@ import Request from './containers/Request';
 import Home from './components/Home';
 import ConfirmEmail from './containers/ConfirmEmail';
 import ForgotPassword from './containers/ForgotPassword';
+import ChangePassword from './containers/ChangePassword';
 import PrivateRoute from './components/PrivateRoute';
 import { reducer } from './reducers/reducer';
 
@@ -33,6 +34,7 @@ function App() {
                         <Route exact path="/signin" component={Signin} />
                         <Route exact path="/forgotpassword" component={ForgotPassword} />
                         <Route exact path="/confirmemail/:token" component={ConfirmEmail} />
+                        <Route exact path="/changepassword/:token" component={ChangePassword} />
 
                         <PrivateRoute exact path="/inbox" component={Inbox} />
                         <PrivateRoute exact path="/createv1" component={RequestCreationPage} />

--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -13,6 +13,7 @@ import RequestCreationPage from './components/RequestCreation/RequestCreationPag
 import Request from './containers/Request';
 import Home from './components/Home';
 import ConfirmEmail from './containers/ConfirmEmail';
+import ForgotPassword from './containers/ForgotPassword';
 import PrivateRoute from './components/PrivateRoute';
 import { reducer } from './reducers/reducer';
 
@@ -30,6 +31,7 @@ function App() {
                         <Route exact path="/" component={Home} />
                         <Route exact path="/signup" component={Signup} />
                         <Route exact path="/signin" component={Signin} />
+                        <Route exact path="/forgotpassword" component={ForgotPassword} />
                         <Route exact path="/confirmemail/:token" component={ConfirmEmail} />
 
                         <PrivateRoute exact path="/inbox" component={Inbox} />

--- a/packages/app/src/components/ChangePasswordForm/ChangePasswordForm.js
+++ b/packages/app/src/components/ChangePasswordForm/ChangePasswordForm.js
@@ -1,0 +1,142 @@
+import React, { useEffect, useState } from 'react';
+import M from 'materialize-css';
+import { useHistory } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import TextField from '../Common/TextField';
+import { changePassword } from '../../services/users';
+
+const css = {
+    formContainer: {
+        padding: '1.5rem 2rem',
+        maxWidth: '670px',
+        margin: '2.5rem auto 0'
+    },
+    cancelButton: {
+        backgroundColor: 'white',
+        color: 'teal',
+        marginRight: '1rem'
+    }
+};
+
+const ChangePasswordForm = () => {
+    const { token } = useParams();
+    const history = useHistory();
+
+    const [isFetching, setIsFetching] = useState(false);
+    const [error, setError] = useState(null);
+
+    const [form, setForm] = useState({
+        password: '',
+        confirmPassword: ''
+    });
+
+    useEffect(() => {
+        if (form.confirmPassword.length > 0 && form.password !== form.confirmPassword) {
+            setError('Passwords do NOT match');
+        }
+        if (form.confirmPassword.length > 0 && form.password === form.confirmPassword) {
+            setError(null);
+        }
+        if (form.password.length > 0 && form.confirmPassword.length === 0) {
+            setError(null);
+        }
+    }, [form]);
+
+    const handleSubmit = e => {
+        e.preventDefault();
+
+        if (isFormValid()) {
+            setIsFetching(true);
+            changePassword(token, form.password)
+                .then(data => {
+                    if (data.success) {
+                        setError(null);
+                        M.toast({
+                            html: 'Your password has been changed',
+                            classes: 'teal',
+                            displayLength: 3000,
+                            completeCallback: () => {
+                                history.push('/signin');
+                            }
+                        });
+                    } else {
+                        setError('Something went wrong; password not changed');
+                    }
+                    setForm({ password: '', confirmPassword: '' });
+                    setIsFetching(false);
+                })
+                .catch(err => console.log(err));
+        } else {
+            setError('Password is not provided. Try again');
+        }
+    };
+
+    const handleChange = e => {
+        setForm({
+            ...form,
+            [e.target.id]: e.target.value
+        });
+    };
+
+    const isFormValid = () => {
+        return form.password.length > 0 && form.password === form.confirmPassword;
+    };
+    const handleCancel = () => {
+        history.push('/');
+    };
+
+    return (
+        <div className="card-panel" style={css.formContainer}>
+            <h4 className="center-align teal-text text-darken-3">Change Password</h4>
+            <form onSubmit={handleSubmit}>
+                <div className="row">
+                    <div className="col s12">
+                        <TextField
+                            label="Password"
+                            icon="lock"
+                            type="password"
+                            name="password"
+                            value={form.password}
+                            handleChange={handleChange}
+                        />
+                    </div>
+                </div>
+                <div className="row">
+                    <div className="col s12">
+                        <TextField
+                            label="Confirm Password"
+                            icon="lock"
+                            type="password"
+                            name="confirmPassword"
+                            value={form.confirmPassword}
+                            error={error}
+                            handleChange={handleChange}
+                        />
+                    </div>
+                </div>
+
+                <div className="row">
+                    <div className="col right">
+                        <button
+                            className="btn"
+                            type="button"
+                            onClick={handleCancel}
+                            style={css.cancelButton}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            className="waves-effect waves-light btn"
+                            type="submit"
+                            data-testid="submit-btn"
+                        >
+                            {`${!isFetching ? 'Change Password' : 'Changing Password...'}`}
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    );
+};
+
+export default ChangePasswordForm;

--- a/packages/app/src/components/ChangePasswordForm/ChangePasswordForm.test.js
+++ b/packages/app/src/components/ChangePasswordForm/ChangePasswordForm.test.js
@@ -1,0 +1,123 @@
+import React from 'react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { render, cleanup, fireEvent, waitForElement } from '@testing-library/react';
+import ChangePasswordForm from './ChangePasswordForm';
+import * as UserDataService from '../../services/users';
+
+jest.mock('../../services/users');
+
+const token = '40a2be43-8628-4c4e-a31c-af755e105330';
+
+describe('ChangePassword Form', () => {
+    afterEach(cleanup);
+
+    it('renders an input for the new password', () => {
+        const { getByLabelText } = render(
+            <MemoryRouter>
+                <ChangePasswordForm />
+            </MemoryRouter>
+        );
+        expect(getByLabelText('Password')).toBeTruthy();
+    });
+
+    it('renders an input to confirm new password', () => {
+        const { getByLabelText } = render(
+            <MemoryRouter>
+                <ChangePasswordForm />
+            </MemoryRouter>
+        );
+        expect(getByLabelText('Confirm Password')).toBeTruthy();
+    });
+
+    it('does not display message if password fields match', () => {
+        const { getByLabelText, queryByText } = render(
+            <MemoryRouter>
+                <ChangePasswordForm />
+            </MemoryRouter>
+        );
+
+        const passwordInput = getByLabelText('Password');
+        const confirmPasswordInput = getByLabelText('Confirm Password');
+        fireEvent.change(passwordInput, { target: { value: 'correctpassword' } });
+        fireEvent.change(confirmPasswordInput, { target: { value: 'correctpassword' } });
+
+        expect(queryByText('Passwords do NOT match')).toBe(null);
+    });
+
+    it('displays a message when the password fields do not match', () => {
+        const { getByLabelText, getByText } = render(
+            <MemoryRouter>
+                <ChangePasswordForm />
+            </MemoryRouter>
+        );
+
+        const passwordInput = getByLabelText('Password');
+        const confirmPasswordInput = getByLabelText('Confirm Password');
+        fireEvent.change(passwordInput, { target: { value: 'correctpassword' } });
+        fireEvent.change(confirmPasswordInput, { target: { value: 'incorrectpassword' } });
+
+        expect(getByText('Passwords do NOT match')).toBeTruthy();
+    });
+
+    it('displays a toast message if the password is changed', async () => {
+        const json = Promise.resolve({
+            success: true,
+            message: 'password changed',
+            payload: { user: {} }
+        });
+
+        UserDataService.changePassword = jest.fn(() => json);
+
+        const { container, getByLabelText, getByText, getByTestId } = render(
+            <MemoryRouter initialEntries={[`/changepassword/${token}`]}>
+                <Route path="/changepassword/:token">
+                    <ChangePasswordForm />
+                </Route>
+            </MemoryRouter>
+        );
+
+        const passwordInput = getByLabelText('Password');
+        const confirmPasswordInput = getByLabelText('Confirm Password');
+        fireEvent.change(passwordInput, { target: { value: 'correctpassword' } });
+        fireEvent.change(confirmPasswordInput, { target: { value: 'correctpassword' } });
+        fireEvent.click(getByTestId('submit-btn'));
+
+        const toast = await waitForElement(() => getByText('Your password has been changed'), {
+            container
+        });
+        expect(toast).toBeTruthy();
+        expect(UserDataService.changePassword).toHaveBeenCalledTimes(1);
+        expect(UserDataService.changePassword).toHaveBeenCalledWith(token, 'correctpassword');
+    });
+
+    it('displays a message if the password is not changed', async () => {
+        const json = Promise.resolve({
+            success: false,
+            message: 'password not changed',
+            payload: { user: null }
+        });
+
+        UserDataService.changePassword = jest.fn(() => json);
+
+        const { container, getByLabelText, getByText, getByTestId } = render(
+            <MemoryRouter initialEntries={[`/changepassword/${token}`]}>
+                <Route path="/changepassword/:token">
+                    <ChangePasswordForm />
+                </Route>
+            </MemoryRouter>
+        );
+
+        const passwordInput = getByLabelText('Password');
+        const confirmPasswordInput = getByLabelText('Confirm Password');
+        fireEvent.change(passwordInput, { target: { value: 'correctpassword' } });
+        fireEvent.change(confirmPasswordInput, { target: { value: 'correctpassword' } });
+        fireEvent.click(getByTestId('submit-btn'));
+
+        const message = await waitForElement(() => getByText(/Something went wrong/i), {
+            container
+        });
+        expect(message).toBeTruthy();
+        expect(UserDataService.changePassword).toHaveBeenCalledTimes(1);
+        expect(UserDataService.changePassword).toHaveBeenCalledWith(token, 'correctpassword');
+    });
+});

--- a/packages/app/src/components/Common/TextField.js
+++ b/packages/app/src/components/Common/TextField.js
@@ -1,10 +1,14 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
-const TextField = ({ type, name, label, validate, value, error, icon, disabled, handleChange }) => {
+const TextField = (
+    { type, name, label, validate, value, error, icon, disabled, handleChange },
+    ref
+) => {
     return (
         <div className="input-field">
             {icon && <i className="small material-icons prefix">{icon}</i>}
             <input
+                ref={ref}
                 className={validate ? 'validate' : ''}
                 type={type}
                 id={name}
@@ -18,14 +22,4 @@ const TextField = ({ type, name, label, validate, value, error, icon, disabled, 
     );
 };
 
-TextField.defaultProps = {
-    type: 'text',
-    name: 'unknown',
-    label: 'Text Label',
-    validat: false,
-    value: '',
-    icon: '',
-    handleChange: () => {}
-};
-
-export default TextField;
+export default forwardRef(TextField);

--- a/packages/app/src/components/ForgotPasswordForm/ForgotPasswordForm.js
+++ b/packages/app/src/components/ForgotPasswordForm/ForgotPasswordForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import M from 'materialize-css';
 import TextField from '../Common/TextField';
@@ -30,6 +30,7 @@ const css = {
 
 const ForgotPasswordForm = () => {
     const history = useHistory();
+    const textFieldRef = useRef();
 
     const [isRequestSent, setIsRequestSent] = useState(false);
     const [email, setEmail] = useState('');
@@ -40,7 +41,8 @@ const ForgotPasswordForm = () => {
         setFormValue(v => '');
         setTimeout(() => {
             M.updateTextFields();
-        }, 500);
+            textFieldRef.current.classList.remove('valid');
+        }, 250);
     }, [email]);
 
     const handleSubmit = e => {
@@ -76,6 +78,7 @@ const ForgotPasswordForm = () => {
                 <div className="row">
                     <div className="col s12">
                         <TextField
+                            ref={textFieldRef}
                             label="Your Email"
                             icon="email"
                             type="text"

--- a/packages/app/src/components/ForgotPasswordForm/ForgotPasswordForm.js
+++ b/packages/app/src/components/ForgotPasswordForm/ForgotPasswordForm.js
@@ -1,0 +1,130 @@
+import React, { useState, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+import M from 'materialize-css';
+import TextField from '../Common/TextField';
+import { forgotPassword } from '../../services/users';
+
+const css = {
+    formContainer: {
+        padding: '1.5rem 2rem',
+        maxWidth: '670px',
+        margin: '2.5rem auto 0'
+    },
+
+    errorText: {
+        padding: '0 4rem',
+        fontSize: '1rem'
+    },
+
+    cancelButton: {
+        backgroundColor: 'white',
+        color: 'teal',
+        marginRight: '1rem'
+    },
+
+    message: {
+        marginTop: '2rem',
+        fontSize: '1.25rem'
+    }
+};
+
+const ForgotPasswordForm = () => {
+    const history = useHistory();
+
+    const [isRequestSent, setIsRequestSent] = useState(false);
+    const [email, setEmail] = useState('');
+    const [formValue, setFormValue] = useState('');
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        setFormValue(v => '');
+        setTimeout(() => {
+            M.updateTextFields();
+        }, 500);
+    }, [email]);
+
+    const handleSubmit = e => {
+        e.preventDefault();
+        if (formValue.length > 0) {
+            forgotPassword(formValue).then(data => {
+                if (data.success) {
+                    setEmail(data.payload.email);
+                    setIsRequestSent(true);
+                } else {
+                    setError('Something went wrong. Please try again.');
+                }
+            });
+        }
+    };
+
+    const handleCancel = () => {
+        history.push('/');
+    };
+
+    const handleChange = e => {
+        setFormValue(e.target.value);
+    };
+
+    return (
+        <div className="card-panel" style={css.formContainer}>
+            <h4 className="center-align teal-text text-darken-3">Reset Password</h4>
+            <p className="grey-text text-darken-1" style={{ fontSize: '1.25rem' }}>
+                Enter the email address associated with your account and we'll send you a link to
+                reset your password.
+            </p>
+            <form onSubmit={handleSubmit}>
+                <div className="row">
+                    <div className="col s12">
+                        <TextField
+                            label="Your Email"
+                            icon="email"
+                            type="text"
+                            name="email"
+                            value={formValue}
+                            handleChange={handleChange}
+                            validate
+                        />
+                    </div>
+                </div>
+                <div className="row">
+                    {error.length > 0 && (
+                        <p className="red-text" style={css.errorText} data-testid="error-message">
+                            {error}
+                        </p>
+                    )}
+                </div>
+                <div className="row">
+                    <div className="col right">
+                        <button
+                            className="btn"
+                            type="button"
+                            onClick={handleCancel}
+                            style={css.cancelButton}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            className="waves-effect waves-light btn"
+                            type="submit"
+                            data-testid="submit-btn"
+                        >
+                            Reset Password
+                        </button>
+                    </div>
+                </div>
+            </form>
+            {isRequestSent && (
+                <p
+                    className="teal-text text-darken-3"
+                    style={css.message}
+                    data-testid="success-message"
+                >
+                    Thank you. An email has been sent to <em>{`${email}`}</em> with instructions to
+                    reset your password.
+                </p>
+            )}
+        </div>
+    );
+};
+
+export default ForgotPasswordForm;

--- a/packages/app/src/components/ForgotPasswordForm/ForgotPasswordForm.test.js
+++ b/packages/app/src/components/ForgotPasswordForm/ForgotPasswordForm.test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render, cleanup, fireEvent, waitForElement } from '@testing-library/react';
+import ForgotPasswordForm from './ForgotPasswordForm';
+import * as UserDataService from '../../services/users';
+
+jest.mock('../../services/users');
+
+describe('Forgotpassword Form', () => {
+    afterEach(cleanup);
+
+    it('renders an input for email', () => {
+        const { getByLabelText } = render(
+            <MemoryRouter>
+                <ForgotPasswordForm />
+            </MemoryRouter>
+        );
+        expect(getByLabelText('Your Email')).toBeTruthy();
+    });
+
+    it('displays message to user if the API call is successful', async () => {
+        const json = Promise.resolve({
+            success: true,
+            message: 'password details sent to user',
+            payload: { user: 'some@email.com' }
+        });
+
+        UserDataService.forgotPassword = jest.fn(() => json);
+
+        const { getByLabelText, getByTestId, container } = render(
+            <MemoryRouter>
+                <ForgotPasswordForm />
+            </MemoryRouter>
+        );
+        const emailInput = getByLabelText('Your Email');
+        fireEvent.change(emailInput, { target: { value: 'some@email.com' } });
+        fireEvent.click(getByTestId('submit-btn'));
+
+        const message = await waitForElement(() => getByTestId('success-message'), { container });
+        expect(message.textContent).toContain('Thank you.');
+        expect(UserDataService.forgotPassword).toHaveBeenCalledWith('some@email.com');
+    });
+
+    it('displays error message if the API call is unsuccessful', async () => {
+        const json = Promise.resolve({
+            success: false,
+            message: 'user not found',
+            payload: { user: null }
+        });
+
+        UserDataService.forgotPassword = jest.fn(() => json);
+
+        const { getByLabelText, getByTestId, container } = render(
+            <MemoryRouter>
+                <ForgotPasswordForm />
+            </MemoryRouter>
+        );
+        const emailInput = getByLabelText('Your Email');
+        fireEvent.change(emailInput, { target: { value: 'unknown-user@email.com' } });
+        fireEvent.click(getByTestId('submit-btn'));
+
+        const message = await waitForElement(() => getByTestId('error-message'), { container });
+        expect(message.textContent).toContain('Something went wrong.');
+        expect(UserDataService.forgotPassword).toHaveBeenCalledWith('unknown-user@email.com');
+    });
+});

--- a/packages/app/src/components/SigninForm/SigninForm.js
+++ b/packages/app/src/components/SigninForm/SigninForm.js
@@ -1,4 +1,5 @@
 import React, { useState, useContext } from 'react';
+import { Link } from 'react-router-dom';
 import M from 'materialize-css';
 import AuthContext from '../../context/AuthContext';
 import TextField from '../Common/TextField';
@@ -12,6 +13,11 @@ const css = {
     },
 
     errorText: {
+        padding: '0 4rem',
+        fontSize: '1rem'
+    },
+
+    forgotPassword: {
         padding: '0 4rem',
         fontSize: '1rem'
     },
@@ -108,11 +114,13 @@ const SigninForm = ({ history }) => {
                         />
                     </div>
                 </div>
-                <div className="row">
-                    <p className="red-text" style={css.errorText}>
-                        {form.errorMsg}
-                    </p>
-                </div>
+                {form.errorMsg.length > 0 && (
+                    <div className="row">
+                        <p className="red-text" style={css.errorText}>
+                            {form.errorMsg}
+                        </p>
+                    </div>
+                )}
                 <div className="row">
                     <div className="col right">
                         <button
@@ -127,6 +135,11 @@ const SigninForm = ({ history }) => {
                             {`${!isFetching ? 'Sign In' : 'Signing In...'}`}
                         </button>
                     </div>
+                </div>
+                <div className="row">
+                    <Link to="/forgotpassword" className="teal-text" style={css.forgotPassword}>
+                        Forgot Password?
+                    </Link>
                 </div>
             </form>
         </div>

--- a/packages/app/src/components/SigninForm/SigninForm.test.js
+++ b/packages/app/src/components/SigninForm/SigninForm.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, cleanup, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import SigninForm from './SigninForm';
 import { AuthProvider } from '../../context/AuthContext';
 import * as Auth from '../../services/auth';
@@ -14,12 +15,20 @@ describe('SigninForm', () => {
     afterEach(cleanup);
 
     it('renders an input for email', () => {
-        const { getByLabelText } = render(<SigninForm />);
+        const { getByLabelText } = render(
+            <MemoryRouter>
+                <SigninForm />{' '}
+            </MemoryRouter>
+        );
         expect(getByLabelText('Your Email')).toBeTruthy();
     });
 
     it('renders an input for password', () => {
-        const { getByLabelText } = render(<SigninForm />);
+        const { getByLabelText } = render(
+            <MemoryRouter>
+                <SigninForm />{' '}
+            </MemoryRouter>
+        );
         expect(getByLabelText('Password')).toBeTruthy();
     });
 
@@ -29,9 +38,11 @@ describe('SigninForm', () => {
             .mockResolvedValue({ success: true, message: 'User authenticated', payload: {} });
 
         const { getByLabelText, getByText } = render(
-            <AuthProvider value={{ login: () => {} }}>
-                <SigninForm history={history} />
-            </AuthProvider>
+            <MemoryRouter>
+                <AuthProvider value={{ login: () => {} }}>
+                    <SigninForm history={history} />
+                </AuthProvider>
+            </MemoryRouter>
         );
         const emailInput = getByLabelText('Your Email');
         const passwordInput = getByLabelText('Password');

--- a/packages/app/src/containers/ChangePassword.js
+++ b/packages/app/src/containers/ChangePassword.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import ChangePasswordForm from '../components/ChangePasswordForm/ChangePasswordForm';
+
+const ChangePassword = () => {
+    return <ChangePasswordForm />;
+};
+
+export default ChangePassword;

--- a/packages/app/src/containers/ForgotPassword.js
+++ b/packages/app/src/containers/ForgotPassword.js
@@ -1,0 +1,16 @@
+import React, { useContext } from 'react';
+import { Redirect } from 'react-router-dom';
+import AuthContext from '../context/AuthContext';
+import ForgotPasswordForm from '../components/ForgotPasswordForm/ForgotPasswordForm';
+
+const ForgotPassword = () => {
+    const authCtx = useContext(AuthContext);
+
+    if (authCtx.contextUser) {
+        return <Redirect to="/" />;
+    }
+
+    return <ForgotPasswordForm />;
+};
+
+export default ForgotPassword;

--- a/packages/app/src/services/users.js
+++ b/packages/app/src/services/users.js
@@ -23,3 +23,15 @@ export const confirmEmail = token => {
         }
     });
 };
+
+export const forgotPassword = email => {
+    return fetch(`${BASE_URL}/api/users/forgotpassword`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+    }).then(res => {
+        if (res.ok && res.status === 200) {
+            return res.json();
+        }
+    });
+};

--- a/packages/app/src/services/users.js
+++ b/packages/app/src/services/users.js
@@ -35,3 +35,15 @@ export const forgotPassword = email => {
         }
     });
 };
+
+export const changePassword = (token, newPassword) => {
+    return fetch(`${BASE_URL}/api/users/changepassword/${token}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ newPassword })
+    }).then(res => {
+        if (res.ok && res.status === 200) {
+            return res.json();
+        }
+    });
+};


### PR DESCRIPTION
This PR adds the ability for a user to request a password reset in the case they may have forgotten their password.  It contains all the necessary API work and new client-side views in order to implement the feature end-to-end.

Fixes #25 