### PR TITLE
Fix Mailer connection error

### DIFF
--- a/packages/api-postgres/src/mailer/Mailer.ts
+++ b/packages/api-postgres/src/mailer/Mailer.ts
@@ -1,4 +1,5 @@
 import nodemailer from 'nodemailer';
+import config from '../config/config';
 import User from '../entity/User';
 import {
     getEmailVerificatonTemplateText,
@@ -18,7 +19,7 @@ class Mailer {
     public static async sendVerificationEmail(baseUrl: string, user: User): Promise<any> {
         const transporter = nodemailer.createTransport(Mailer.getMailOptions());
         const verifiedTransporter =
-            process.env.NODE_ENV === 'testingE2E' || process.env.NODE_ENV === 'testing'
+            config.env === 'testingE2E' || config.env === 'testing'
                 ? true
                 : await transporter.verify();
 
@@ -36,7 +37,7 @@ class Mailer {
     public static async sendPasswordResetEmail(baseUrl: string, user: User): Promise<any> {
         const transporter = nodemailer.createTransport(Mailer.getMailOptions());
         const verifiedTransporter =
-            process.env.NODE_ENV === 'testingE2E' || process.env.NODE_ENV === 'testing'
+            config.env === 'testingE2E' || config.env === 'testing'
                 ? true
                 : await transporter.verify();
 
@@ -53,7 +54,7 @@ class Mailer {
 
     private static getMailOptions(): MailOptions {
         let mailOpts = {};
-        switch (process.env.NODE_ENV) {
+        switch (config.env) {
             case 'production':
                 // add mail options to connect to outgoing email account
                 // when one is identified


### PR DESCRIPTION
Weird.  For some reason after the last round of version updates, a call to `process.env.NODE_ENV` in `Mailer.ts` was returning `undefined`, which caused the `Mailer` to attempt to connect to a default smtp server on port 587.  This obviously failed because there was not one there.

This fixes the issue to read the environment from the `config` vice `process.env`, which turns out may not be set properly when in `development` mode.