### PR TITLE
Update postgres image to v13

### DIFF
--- a/packages/api-postgres/docker-compose.yml
+++ b/packages/api-postgres/docker-compose.yml
@@ -13,7 +13,7 @@ services:
 
     postgres:
         container_name: pdb
-        image: postgres:12-alpine
+        image: postgres:13-alpine
         restart: unless-stopped
         ports:
             - '5432:5432'
@@ -24,6 +24,7 @@ services:
             - sandbox
         volumes:
             - ./data/postgres:/var/lib/postgresql/data
+            - .:/home/desc/
 
     pgadmin:
         container_name: pgadmin


### PR DESCRIPTION
Update postgres image to v13 and add a mapped volume to access the `api-postgres` package root in the container.

Fixes #52 