### PR TITLE
API endpoints to activate/deactivate user

### DIFF
--- a/packages/api-postgres/src/common/types.ts
+++ b/packages/api-postgres/src/common/types.ts
@@ -24,6 +24,7 @@ export interface UserFields {
     roles?: UserRole[];
     isEmailVerified?: boolean;
     emailVerificationToken?: string;
+    isActive?: boolean;
 }
 
 export type UpdatableUserFields = Partial<Omit<UserFields, 'password' | 'roles'>>;

--- a/packages/api-postgres/src/config/strategies/local.ts
+++ b/packages/api-postgres/src/config/strategies/local.ts
@@ -20,8 +20,13 @@ const verifyCb: PassportLocal.VerifyFunction = async (
     if (!user.verifyPassword(password)) {
         return done(null, false, { message: 'Bad user credentials provided' });
     }
+
+    if (!user.isActive) {
+        return done(null, false, { message: 'User is no longer active' });
+    }
+
     user.lastLoginAt = new Date();
-    return user.save().then(updatedUser => done(null, updatedUser));
+    return user.save().then((updatedUser) => done(null, updatedUser));
 };
 
 export default new LocalStrategy(opts, verifyCb);

--- a/packages/api-postgres/src/entity/User.ts
+++ b/packages/api-postgres/src/entity/User.ts
@@ -64,6 +64,9 @@ export default class User extends BaseEntity {
     @Column({ nullable: true })
     lastLoginAt: Date;
 
+    @Column({ default: true })
+    isActive: boolean;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/packages/api-postgres/src/testUtils/TestClient.ts
+++ b/packages/api-postgres/src/testUtils/TestClient.ts
@@ -62,6 +62,22 @@ class TestClient extends BaseTestClient {
             .set('Authorization', `Bearer ${this.accessToken}`);
     }
 
+    public deactivateUser(id: string): Test {
+        return request(this.app)
+            .post(`/api/users/${id}/deactivate`)
+            .set('Content-Type', 'application/json')
+            .set('Cookie', [`qid=${this.refreshToken}`])
+            .set('Authorization', `Bearer ${this.accessToken}`);
+    }
+
+    public activateUser(id: string): Test {
+        return request(this.app)
+            .post(`/api/users/${id}/activate`)
+            .set('Content-Type', 'application/json')
+            .set('Cookie', [`qid=${this.refreshToken}`])
+            .set('Authorization', `Bearer ${this.accessToken}`);
+    }
+
     public loginUser(email: string, password: string): Test {
         return request(this.app)
             .post('/api/auth/login')

--- a/packages/api-postgres/src/user/UserController.ts
+++ b/packages/api-postgres/src/user/UserController.ts
@@ -152,6 +152,66 @@ class UserController {
             });
     }
 
+    static deactivateUser(req: Request, res: Response): Promise<Response> {
+        const id = req.params.id;
+        return UserService.setIsActive(id, false)
+            .then((deactivatedUser) => {
+                if (deactivatedUser) {
+                    return res.json({
+                        success: true,
+                        message: 'user deactivated',
+                        payload: { user: deactivatedUser }
+                    });
+                } else {
+                    return res.json({
+                        success: false,
+                        message: 'user not found',
+                        payload: { user: null }
+                    });
+                }
+            })
+            .catch((err) => {
+                return res.json({
+                    success: false,
+                    message: 'error deactivating user',
+                    payload: {
+                        error: err.message,
+                        user: null
+                    }
+                });
+            });
+    }
+
+    static activateUser(req: Request, res: Response): Promise<Response> {
+        const id = req.params.id;
+        return UserService.setIsActive(id, true)
+            .then((activatedUser) => {
+                if (activatedUser) {
+                    return res.json({
+                        success: true,
+                        message: 'user activated',
+                        payload: { user: activatedUser }
+                    });
+                } else {
+                    return res.json({
+                        success: false,
+                        message: 'user not found',
+                        payload: { user: null }
+                    });
+                }
+            })
+            .catch((err) => {
+                return res.json({
+                    success: false,
+                    message: 'error activating user',
+                    payload: {
+                        error: err.message,
+                        user: null
+                    }
+                });
+            });
+    }
+
     static confirmEmail(req: Request, res: Response): Promise<Response> {
         const emailToken = req.params.token;
         return UserService.confirmEmail(emailToken)

--- a/packages/api-postgres/src/user/UserRouter.ts
+++ b/packages/api-postgres/src/user/UserRouter.ts
@@ -40,6 +40,18 @@ class UserRouter {
             .patch(isAdminOrSelf, UserController.updateUser)
             .delete(isAdminOrSelf, UserController.deleteUser);
 
+        UserRouter.router
+            .route(
+                '/:id([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/deactivate'
+            )
+            .post(isAdmin, UserController.deactivateUser);
+
+        UserRouter.router
+            .route(
+                '/:id([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/activate'
+            )
+            .post(isAdmin, UserController.activateUser);
+
         UserRouter.router.route('/confirmemail/:token').patch(UserController.confirmEmail);
         UserRouter.router.route('/changepassword/:token').patch(UserController.changePassword);
     }

--- a/packages/api-postgres/src/user/UserService.ts
+++ b/packages/api-postgres/src/user/UserService.ts
@@ -66,12 +66,8 @@ export default class UserService {
         return user;
     }
 
-    static async setIsActive(id: string, isActive: boolean): Promise<User | undefined> {
-        const user = await UserService.getUserById(id);
-        if (user) {
-            user.isActive = isActive;
-        }
-        return user;
+    static async setIsActive(id: string, isUserActive: boolean): Promise<User | undefined> {
+        return UserService.updateUser(id, { isActive: isUserActive });
     }
 
     static async confirmEmail(token: string): Promise<User | undefined> {

--- a/packages/api-postgres/src/user/UserService.ts
+++ b/packages/api-postgres/src/user/UserService.ts
@@ -66,6 +66,14 @@ export default class UserService {
         return user;
     }
 
+    static async setIsActive(id: string, isActive: boolean): Promise<User | undefined> {
+        const user = await UserService.getUserById(id);
+        if (user) {
+            user.isActive = isActive;
+        }
+        return user;
+    }
+
     static async confirmEmail(token: string): Promise<User | undefined> {
         const user = await User.findOne({ where: { emailVerificationToken: token } });
         return UserService.updateUser(user?.id as string, {

--- a/packages/api-postgres/src/user/__tests__/UserService.test.ts
+++ b/packages/api-postgres/src/user/__tests__/UserService.test.ts
@@ -156,6 +156,49 @@ describe('User service integration tests', () => {
         });
     });
 
+    describe('setIsActive method', () => {
+        let userIdToTest: string;
+
+        beforeEach(async () => {
+            await UserService.createUser({
+                firstName: 'Barry',
+                lastName: 'Allen',
+                email: 'barry@starlabs.com',
+                password: 'test1234'
+            });
+            const { firstName, lastName, email, password, program } = testUser;
+            const user = await UserService.createUser({
+                firstName,
+                lastName,
+                email,
+                password,
+                program
+            });
+            userIdToTest = user.id;
+        });
+
+        afterEach(async () => {
+            await TestUtils.dropUsers();
+        });
+
+        it('returns undefined if user cannot be found with given id', async () => {
+            const result = await UserService.deleteUser('4157b081-e365-4984-aeac-c31aa255a474');
+            expect(result).toBeUndefined();
+        });
+
+        it(`deactivates the user with the given id`, async () => {
+            const result = await UserService.setIsActive(userIdToTest, false);
+            expect(result?.id).toEqual(userIdToTest);
+            expect(result?.isActive).toBe(false);
+        });
+
+        it(`activates the user with the given id`, async () => {
+            const result = await UserService.setIsActive(userIdToTest, true);
+            expect(result?.id).toEqual(userIdToTest);
+            expect(result?.isActive).toBe(true);
+        });
+    });
+
     describe('confirmEmail method', () => {
         let emailToken: string;
 

--- a/packages/api-postgres/src/user/__tests__/user.acceptance-test.ts
+++ b/packages/api-postgres/src/user/__tests__/user.acceptance-test.ts
@@ -334,6 +334,108 @@ describe('User route acceptance tests', () => {
         });
     });
 
+    describe('/api/users/:id/deactivate route', () => {
+        const unknownId = '9ff6515e-814a-4d1c-bc27-9a768c4aa242';
+        const adminEmail = 'admin@desc.org';
+        const requestor1Email = 'oliver@desc.org';
+        const requestor2Email = 'barry@desc.org';
+        const password = '123456';
+
+        let requestorId1: string;
+        let requestorId2: string;
+        let client: TestClient;
+
+        beforeAll(() => {
+            client = new TestClient();
+        });
+
+        afterEach(async () => {
+            await TestUtils.dropUsers();
+        });
+
+        beforeEach(async () => {
+            await TestUtils.createAdminTestUser({
+                firstName: 'Admin',
+                lastName: 'User',
+                email: adminEmail,
+                password,
+                program: Program.SURVIVAL
+            });
+
+            const user1 = await TestUtils.createTestUser({
+                firstName: 'Oliver',
+                lastName: 'Queen',
+                email: requestor1Email,
+                password,
+                program: Program.SURVIVAL
+            });
+            requestorId1 = user1.id;
+
+            const user2 = await TestUtils.createTestUser({
+                firstName: 'Barry',
+                lastName: 'Allen',
+                email: requestor2Email,
+                password,
+                program: Program.HOUSING
+            });
+            requestorId2 = user2.id;
+        });
+
+        describe('POST request method', () => {
+            it('deactivates an active user', async () => {
+                await client.doLogin(adminEmail, password);
+                const response = await client.deactivateUser(requestorId1);
+                expect(response.body).toEqual(
+                    expect.objectContaining({
+                        success: true,
+                        message: 'user deactivated',
+                        payload: expect.objectContaining({
+                            user: expect.objectContaining({
+                                isActive: false
+                            })
+                        })
+                    })
+                );
+            });
+
+            it('returns a null user in the payload if the user id does not exist', async () => {
+                await client.doLogin(adminEmail, password);
+                const response = await client.deactivateUser(unknownId);
+                expect(response.body).toEqual(
+                    expect.objectContaining({
+                        success: false,
+                        message: 'user not found',
+                        payload: expect.objectContaining({
+                            user: null
+                        })
+                    })
+                );
+            });
+
+            it('returns an error if a non-admin attempts to deactivate another user', async () => {
+                await client.doLogin(requestor1Email, password);
+                const response = await client.deactivateUser(requestorId2);
+                expect(response.body).toEqual(
+                    expect.objectContaining({
+                        success: false,
+                        message: expect.stringMatching(/^Error/),
+                        payload: expect.objectContaining({
+                            error: expect.stringMatching(/insufficient access/i)
+                        })
+                    })
+                );
+            });
+        });
+    });
+
+    describe('/api/users/:id/activate route', () => {
+        describe('POST request method', () => {
+            it.todo('activates an inactive user');
+            it.todo('returns a null user in the payload if the user id does not exist');
+            it.todo('returns an error if a non-admin attempts to activate another user');
+        });
+    });
+
     describe('/api/users/confirmemail/:token route', () => {
         let client: TestClient;
         let emailToken: string;


### PR DESCRIPTION
This PR add the necessary API endpoints and changes to enable an admin to activate/deactivate a user.  Specifically, this PR:

* Add endpoint `POST /api/user/:id/activate`
* Add endpont `POST /api/user/:id/deactivate`
* Blocks deactivated or inactive users from logging in.  They will receive a status `401`, same as an attempt to login with invalid user credentials

Fixes #63 