### PR TITLE
Update all services to use entity manager

### DIFF
--- a/packages/api-postgres/src/clientRequest/ClientRequestService.ts
+++ b/packages/api-postgres/src/clientRequest/ClientRequestService.ts
@@ -3,6 +3,7 @@ import { ItemFields } from '../common/types/items';
 import UserService from '../user/UserService';
 import ItemService from '../item/ItemService';
 import Item from '../entity/Item';
+import { getEntityManager } from '../common/entityUtils';
 
 interface ClientRequestData {
     clientId: string;
@@ -11,6 +12,7 @@ interface ClientRequestData {
 }
 export default class ClientRequestService {
     static async createClientRequest(data: ClientRequestData): Promise<ClientRequest> {
+        const em = getEntityManager();
         const { clientId, requestorId, items } = data;
         const clientRequest = new ClientRequest();
         clientRequest.clientId = clientId;
@@ -22,7 +24,7 @@ export default class ClientRequestService {
         clientRequest.submittedBy = requestor;
 
         if (!items) {
-            return clientRequest.save();
+            return em.save(clientRequest);
         }
 
         if (Array.isArray(items)) {
@@ -40,15 +42,15 @@ export default class ClientRequestService {
             clientRequest.items = [tempItem];
         }
 
-        return clientRequest.save();
+        return em.save(clientRequest);
     }
 
     static async getAllClientRequests(): Promise<ClientRequest[]> {
-        return ClientRequest.find({ relations: ['submittedBy', 'items'] });
+        return getEntityManager().find(ClientRequest, { relations: ['submittedBy', 'items'] });
     }
 
     static getClientRequestById(id: string): Promise<ClientRequest | undefined> {
-        return ClientRequest.findOne({
+        return getEntityManager().findOne(ClientRequest, {
             where: { id },
             relations: ['submittedBy', 'items']
         });

--- a/packages/api-postgres/src/common/entityUtils.ts
+++ b/packages/api-postgres/src/common/entityUtils.ts
@@ -1,0 +1,6 @@
+import { EntityManager } from 'typeorm';
+import { getDbConnection } from '../config/database';
+
+export function getEntityManager(): EntityManager {
+    return getDbConnection().manager;
+}

--- a/packages/api-postgres/src/config/database.ts
+++ b/packages/api-postgres/src/config/database.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { createConnection, getConnection, getConnectionOptions } from 'typeorm';
+import { Connection, createConnection, getConnection } from 'typeorm';
 import config from './config';
 
 const envDbNameMap: Map<string, string> = new Map();
@@ -7,21 +7,24 @@ envDbNameMap.set('development', 'desc-dev');
 envDbNameMap.set('testing', 'desc-test');
 envDbNameMap.set('testingE2E', 'desc-test');
 
-const dbName: string = envDbNameMap.get(config.env) as string;
+const connectionName: string = envDbNameMap.get(config.env) as string;
 
-export const createPostgresConnection = async (): Promise<void> => {
+export async function createPostgresConnection(): Promise<void> {
     try {
         if (config.env != 'production') {
-            const connectionOptions = await getConnectionOptions(dbName);
-            await createConnection({ ...connectionOptions, name: 'default' });
+            await createConnection(connectionName);
         }
         // else connect to heroku hosted postres
         // instance assigned to env var DATABASE_URL
     } catch (e) {
         console.error(e);
     }
-};
+}
 
-export const closeConnection = (): Promise<void> => {
-    return getConnection().close();
-};
+export function closeConnection(): Promise<void> {
+    return getConnection(connectionName).close();
+}
+
+export function getDbConnection(): Connection {
+    return getConnection(connectionName);
+}

--- a/packages/api-postgres/src/config/strategies/local.ts
+++ b/packages/api-postgres/src/config/strategies/local.ts
@@ -1,4 +1,5 @@
 import PassportLocal, { IVerifyOptions } from 'passport-local';
+import { getEntityManager } from '../../common/entityUtils';
 import UserService from '../../user/UserService';
 
 const LocalStrategy = PassportLocal.Strategy;
@@ -12,6 +13,7 @@ const verifyCb: PassportLocal.VerifyFunction = async (
     password: string,
     done: (error: any, user?: any, options?: IVerifyOptions) => void
 ): Promise<void> => {
+    const em = getEntityManager();
     const user = await UserService.getUserByEmail(email);
     if (!user) {
         return done(null, false, { message: 'Unable to find user' });
@@ -26,7 +28,7 @@ const verifyCb: PassportLocal.VerifyFunction = async (
     }
 
     user.lastLoginAt = new Date();
-    return user.save().then((updatedUser) => done(null, updatedUser));
+    return em.save(user).then((updatedUser) => done(null, updatedUser));
 };
 
 export default new LocalStrategy(opts, verifyCb);

--- a/packages/api-postgres/src/note/NoteService.ts
+++ b/packages/api-postgres/src/note/NoteService.ts
@@ -2,11 +2,13 @@ import Note from '../entity/Note';
 import UserService from '../user/UserService';
 import ItemService from '../item/ItemService';
 import { NoteFields } from '../common/types/notes';
+import { getEntityManager } from '../common/entityUtils';
 
 export default class NoteService {
     static async createNote(noteData: NoteFields): Promise<Note | undefined> {
+        const em = getEntityManager();
         const { body, userId, itemId } = noteData;
-        const note = Note.create({ body });
+        const note = em.create(Note, { body });
 
         if (userId && itemId) {
             const user = await UserService.getUserById(userId);
@@ -23,30 +25,36 @@ export default class NoteService {
             note.item = item;
         }
 
-        return note.save();
+        return em.save(note);
     }
 
     static createNoteForItem(noteData: NoteFields): Note {
         const { body } = noteData;
-        const note = Note.create({ body });
+        const note = getEntityManager().create(Note, { body });
         return note;
     }
 
     static getAllNotes(): Promise<Note[]> {
-        return Note.find({ relations: ['submittedBy', 'item'] });
+        return getEntityManager().find(Note, { relations: ['submittedBy', 'item'] });
     }
 
     static getNoteById(id: string): Promise<Note | undefined> {
-        return Note.findOne({ where: { id }, relations: ['submittedBy', 'item'] });
+        return getEntityManager().findOne(Note, {
+            where: { id },
+            relations: ['submittedBy', 'item']
+        });
     }
 
     static getNoteForItem(itemId: string): Promise<Note[]> {
-        return Note.find({ where: { item: itemId }, relations: ['submittedBy', 'item'] });
+        return getEntityManager().find(Note, {
+            where: { item: itemId },
+            relations: ['submittedBy', 'item']
+        });
     }
 
     static async deleteNote(id: string): Promise<Note | undefined> {
         const note = await NoteService.getNoteById(id);
-        await Note.delete({ id });
+        await getEntityManager().delete(Note, { id });
         return note;
     }
 }

--- a/packages/api-postgres/src/testUtils/TestUtilities.ts
+++ b/packages/api-postgres/src/testUtils/TestUtilities.ts
@@ -1,10 +1,10 @@
-import { getConnection } from 'typeorm';
 import User from '../entity/User';
 import Item from '../entity/Item';
 import Note from '../entity/Note';
 import ClientRequest from '../entity/ClientRequest';
 import { Program } from '../common/types/enums';
 import UserService from '../user/UserService';
+import { getDbConnection } from '../config/database';
 
 class TestUtilities {
     public static createTestUser(userData: {
@@ -30,7 +30,7 @@ class TestUtilities {
     }
 
     public static async deleteUserByEmail(email: string): Promise<void> {
-        await getConnection()
+        await getDbConnection()
             .createQueryBuilder()
             .delete()
             .from(User)
@@ -39,19 +39,19 @@ class TestUtilities {
     }
 
     public static async dropItems(): Promise<void> {
-        await getConnection().createQueryBuilder().delete().from(Item).execute();
+        await getDbConnection().createQueryBuilder().delete().from(Item).execute();
     }
 
     public static async dropUsers(): Promise<void> {
-        await getConnection().createQueryBuilder().delete().from(User).execute();
+        await getDbConnection().createQueryBuilder().delete().from(User).execute();
     }
 
     public static async dropNotes(): Promise<void> {
-        await getConnection().createQueryBuilder().delete().from(Note).execute();
+        await getDbConnection().createQueryBuilder().delete().from(Note).execute();
     }
 
     public static async dropClientRequests(): Promise<void> {
-        await getConnection().createQueryBuilder().delete().from(ClientRequest).execute();
+        await getDbConnection().createQueryBuilder().delete().from(ClientRequest).execute();
     }
 }
 


### PR DESCRIPTION
In preps to get the project on heroku, which will require a _production_ db connection, this PR refactors all services to utilize a `typeorm` entity manager.  This change will facilitate an easy switch between the `dev` db and the `prod` db (at least that is the plan 🙂 )