### PR TITLE
refactor: add useFilterItemsByStatus custom hook

### DIFF
--- a/packages/app/src/components/Inbox/ApproverItemList.js
+++ b/packages/app/src/components/Inbox/ApproverItemList.js
@@ -1,11 +1,17 @@
 import M from 'materialize-css';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import useUpdateItem from '../../hooks/useUpdateItem';
 import { useQueryClient } from 'react-query';
 import ApproverActions from './ApproverActions';
 import NoteDetails from './NoteDetails';
 import AddNoteForm from './AddNoteForm';
-import { inboxStyles as css, initCollapsibleElements, closedStatuses } from './utils';
+import {
+    inboxStyles as css,
+    initCollapsibleElements,
+    closedStatuses,
+    updateItemsWithNote
+} from './utils';
+import useFilterItemsByStatus from '../../hooks/useFilterItemsByStatus';
 
 const statusMap = {
     denied: 'Rejected',
@@ -27,7 +33,7 @@ const ListHeader = () => {
 };
 
 const ApproverItemList = ({ filter, items }) => {
-    const [displayableItems, setDisplayableItems] = useState([]);
+    const [displayableItems, setDisplayableItems] = useFilterItemsByStatus(items, filter);
     const queryClient = useQueryClient();
 
     const { updateItem } = useUpdateItem((response) => {
@@ -40,32 +46,8 @@ const ApproverItemList = ({ filter, items }) => {
         initCollapsibleElements(M);
     }, []);
 
-    useEffect(() => {
-        setDisplayableItems(
-            items.filter((item) => {
-                if (Array.isArray(filter)) {
-                    return filter.some((status) => status === item.status);
-                }
-                return item.status === filter;
-            })
-        );
-    }, [items, filter]);
-
     const handleNoteAdd = (itemId, itemData) => {
-        setDisplayableItems(
-            displayableItems.map((item) => {
-                if (item.id === itemId) {
-                    return {
-                        ...item,
-                        updatedAt: itemData.updatedAt,
-                        notes: [...itemData.notes]
-                    };
-                }
-                return {
-                    ...item
-                };
-            })
-        );
+        setDisplayableItems(displayableItems.map(updateItemsWithNote(itemId, itemData)));
     };
 
     const updateItemStatus = (id, status) => {

--- a/packages/app/src/components/Inbox/RequestorItemList.js
+++ b/packages/app/src/components/Inbox/RequestorItemList.js
@@ -1,8 +1,9 @@
 import M from 'materialize-css';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import NoteDetails from './NoteDetails';
 import AddNoteForm from './AddNoteForm';
-import { inboxStyles as css, initCollapsibleElements } from './utils';
+import { inboxStyles as css, initCollapsibleElements, updateItemsWithNote } from './utils';
+import useFilterItemsByStatus from '../../hooks/useFilterItemsByStatus';
 
 const ListHeader = () => {
     return (
@@ -18,31 +19,14 @@ const ListHeader = () => {
 };
 
 const RequestorItemList = ({ items, filter }) => {
-    const [displayableItems, setDisplayableItems] = useState([]);
+    const [displayableItems, setDisplayableItems] = useFilterItemsByStatus(items, filter);
 
     useEffect(() => {
         initCollapsibleElements(M);
     }, []);
 
-    useEffect(() => {
-        setDisplayableItems(items.filter((item) => item.status === filter));
-    }, [items, filter]);
-
     const handleNoteAdd = (itemId, itemData) => {
-        setDisplayableItems(
-            displayableItems.map((item) => {
-                if (item.id === itemId) {
-                    return {
-                        ...item,
-                        updatedAt: itemData.updatedAt,
-                        notes: [...itemData.notes]
-                    };
-                }
-                return {
-                    ...item
-                };
-            })
-        );
+        setDisplayableItems(displayableItems.map(updateItemsWithNote(itemId, itemData)));
     };
 
     return (

--- a/packages/app/src/components/Inbox/utils.js
+++ b/packages/app/src/components/Inbox/utils.js
@@ -41,3 +41,18 @@ export function initCollapsibleElements(materializeLib) {
         onCloseEnd: onCloseEndCb
     });
 }
+
+export function updateItemsWithNote(itemId, itemData) {
+    return (item) => {
+        if (item.id === itemId) {
+            return {
+                ...item,
+                updatedAt: itemData.updatedAt,
+                notes: [...itemData.notes]
+            };
+        }
+        return {
+            ...item
+        };
+    };
+}

--- a/packages/app/src/hooks/useFilterItemsByStatus.js
+++ b/packages/app/src/hooks/useFilterItemsByStatus.js
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+function useFilterItemsByStatus(items, filter) {
+    const [list, setList] = useState([]);
+    useEffect(() => {
+        const filteredList = items.filter((item) => {
+            if (Array.isArray(filter)) {
+                return filter.some((status) => status === item.status);
+            }
+            return item.status === filter;
+        });
+        setList(filteredList);
+    }, [items, filter]);
+
+    return [list, setList];
+}
+
+export default useFilterItemsByStatus;


### PR DESCRIPTION
This PR simplifies the approver's and requestor's request lists by adding a `useFilterItemsByStatus` custom hook, which abstracts much of the logic. 